### PR TITLE
Bugfix: python content decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This package is an implementation of the Citrination API.
 
 ## Installation
 
+### Requirements
+ * Python >= 2.7 or >= 3.4
+ 
 ### Setup
 
 ```shell

--- a/citrination_client/client.py
+++ b/citrination_client/client.py
@@ -61,12 +61,11 @@ class CitrinationClient(object):
 
         :param file_path: File path to upload.
         :param data_set_id: The dataset id to upload the file to.
-        :return: Response object or None if the file was not uploaded.
+        :return: Response object or return code if the file was not uploaded.
         """
         if os.path.isdir(str(file_path)):
             for path, subdirs, files in os.walk(file_path):
                 for name in files:
-                    root = None
                     if root_path:
                        root = root_path
                     else:
@@ -83,7 +82,7 @@ class CitrinationClient(object):
 
             r = requests.post(url, data=json.dumps(file_data), headers=self.headers)
             if r.status_code == 200:
-                j = json.loads(r.content)
+                j = json.loads(r.content.decode('utf-8'))
                 s3url = self._get_s3_presigned_url(j)
                 with open(file_path, 'rb') as f:
                     r = requests.put(s3url, data=f)
@@ -100,7 +99,9 @@ class CitrinationClient(object):
                                    "status": r.status_code}
                         return json.dumps(message)
             else:
-                return None
+                message = {"message": "Upload failed.",
+                                   "status": r.status_code}
+                return json.dumps(message)
 
     def get_dataset_files(self, dataset_id, latest = False):
         """
@@ -157,7 +158,7 @@ class CitrinationClient(object):
         """
         result = requests.get(url, headers=self.headers)
         if result.status_code == 200:
-            return json.loads(result.content)
+            return json.loads(result.content.decode('utf-8'))
         else:
             print('An error ocurred during this action: ' + str(result.status_code) + ' - ' + str(result.reason) )
             return False

--- a/citrination_client/tests/test_client.py
+++ b/citrination_client/tests/test_client.py
@@ -1,0 +1,24 @@
+from citrination_client import CitrinationClient
+from os import environ
+from json import loads
+from pypif.obj.system import System
+from tempfile import TemporaryDirectory
+from pypif.pif import dump
+from os.path import join
+
+def test_start_client():
+    client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://stage.citrination.com')
+
+
+def test_upload_pif():
+    client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://stage.citrination.com')
+    dataset = loads(client.create_data_set(name="Tutorial dataset", description="Dataset for tutorial", share=0).content.decode('utf-8'))['id']
+    pif = System()
+    pif.id = 0
+
+    with TemporaryDirectory() as tmpdir:
+        tempname = join(tmpdir, "pif.json")
+        with open(tempname, "w") as fp:
+            dump(pif, fp)
+        response = loads(client.upload_file(tempname, dataset))
+    assert response["message"] == "Upload is complete."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pypif
+requests
+six

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='1.2.1',
+      version='1.2.2',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(),


### PR DESCRIPTION
Python3 requests are encoded byte-strings, so they need a decode.  It doesn't bother the python2 workings, which the test will enforce.

CC: @kjaym 