### PR TITLE
Set required Python version >= 2.7.10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package is an implementation of the Citrination API.
 ## Installation
 
 ### Requirements
- * Python >= 2.7 or >= 3.4
+ * Python >= 2.7.10 or >= 3.4
  
 ### Setup
 
@@ -15,7 +15,8 @@ This package is an implementation of the Citrination API.
 $ pip install citrination-client
 ```
 
-There are known issues installing libraries that depend on six on OSX. If you have issues installing this library, run the following command:
+There are known issues installing libraries that depend on six on OSX. If you
+have issues installing this library, run the following command:
 
 ```
 $ pip install --ignore-installed six citrination-client
@@ -29,15 +30,20 @@ the legacy branch on this repo.
 
 ### Troubleshooting
 
-It is possible that you will run into problems if you are using an older version of OpenSSL and running MacOSX. If the following error happens when using the requests library to retrieve information from citrination:
+It is possible that you will run into problems if you are using an older
+version of OpenSSL and running MacOSX. If the following error happens when
+using the requests library to retrieve information from citrination:
 
 ```
 requests.exceptions.SSLError: ("bad handshake: Error([('SSL routines', 'SSL23_GET_SERVER_HELLO', 'sslv3 alert handshake failure')],)",)
 ```
 
-Check to see that you are using a current version of OpenSSL. This error was first encountered using OpenSSL 0.9.8zh 14 Jan 2016, and was resolved by upgrading to 'OpenSSL 1.0.2j  26 Sep 2016'.
+Check to see that you are using a current version of OpenSSL. This error was
+first encountered using `OpenSSL 0.9.8zh 14 Jan 2016`, and was resolved by
+upgrading to `OpenSSL 1.0.2j 26 Sep 2016`.
 
-After upgrading OpenSSL, make sure that your python installation is using the correct version:
+After upgrading OpenSSL, make sure that your python installation is using the
+correct version:
 
 ```
 python -c "import ssl; print ssl.OPENSSL_VERSION"


### PR DESCRIPTION
Python versions < 2.7.9 have SSL certificate problems that can cause
clients to reject valid server certificates.

cf. http://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings

This manifests as:
```
In [5]: print("Found {} PIFs in dataset {}".format(client.search(query_dataset).total_num_hits, dataset_id))
/home/maxhutch/anaconda2/lib/python2.7/site-packages/requests-2.10.0-py2.7.egg/requests/packages/urllib3/util/ssl_.py:318: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#snimissingwarning.
  SNIMissingWarning
/home/maxhutch/anaconda2/lib/python2.7/site-packages/requests-2.10.0-py2.7.egg/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
---------------------------------------------------------------------------
SSLError                                  Traceback (most recent call last)
...
SSLError: [Errno 1] _ssl.c:510: error:14077438:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert internal error
```