### PR TITLE
Feature/extract when missing

### DIFF
--- a/citrination_client/search/pif/query/chemical/chemical_field_operation.py
+++ b/citrination_client/search/pif/query/chemical/chemical_field_operation.py
@@ -7,18 +7,22 @@ class ChemicalFieldOperation(BaseFieldOperation):
     Class for all field operations against chemical information.
     """
 
-    def __init__(self, filter=None, extract_as=None, extract_all=None, length=None, offset=None):
+    def __init__(self, filter=None, extract_as=None, extract_all=None, extract_when_missing=None,
+                 length=None, offset=None):
         """
         Constructor.
 
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param length: One or more :class:`.FieldOperation` objects against the length field.
         :param offset: One or more :class:`.FieldOperation` objects against the offset field.
         :param filter: One or more :class:`.ChemicalFilter` objects against this field.
         """
         super(ChemicalFieldOperation, self).__init__(extract_as=extract_as, extract_all=extract_all,
-                                                     length=length, offset=offset)
+                                                     extract_when_missing=extract_when_missing, length=length,
+                                                     offset=offset)
         self._filter = None
         self.filter = filter
 

--- a/citrination_client/search/pif/query/chemical/composition_query.py
+++ b/citrination_client/search/pif/query/chemical/composition_query.py
@@ -10,7 +10,7 @@ class CompositionQuery(BaseObjectQuery):
 
     def __init__(self, element=None, actual_weight_percent=None, actual_atomic_percent=None,
                  ideal_weight_percent=None, ideal_atomic_percent=None, logic=None, extract_as=None,
-                 extract_all=None, tags=None, length=None, offset=None):
+                 extract_all=None, extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -26,12 +26,15 @@ class CompositionQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
         super(CompositionQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
-                                               tags=tags, length=length, offset=offset)
+                                               extract_when_missing=extract_when_missing, tags=tags, length=length,
+                                               offset=offset)
         self._element = None
         self.element = element
         self._actual_weight_percent = None

--- a/citrination_client/search/pif/query/core/base_field_operation.py
+++ b/citrination_client/search/pif/query/core/base_field_operation.py
@@ -6,12 +6,14 @@ class BaseFieldOperation(Serializable):
     Base class for all field operations.
     """
 
-    def __init__(self, extract_as=None, extract_all=None, length=None, offset=None):
+    def __init__(self, extract_as=None, extract_all=None, extract_when_missing=None, length=None, offset=None):
         """
         Constructor.
 
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param length: One or more :class:`.FieldOperation` operations against the length field.
         :param offset: One or more :class:`.FieldOperation` operations against the offset field.
         """
@@ -19,6 +21,8 @@ class BaseFieldOperation(Serializable):
         self.extract_as = extract_as
         self._extract_all = None
         self.extract_all = extract_all
+        self._extract_when_missing = None
+        self.extract_when_missing = extract_when_missing
         self._length = None
         self.length = length
         self._offset = None
@@ -47,6 +51,18 @@ class BaseFieldOperation(Serializable):
     @extract_all.deleter
     def extract_all(self):
         self._extract_all = None
+
+    @property
+    def extract_when_missing(self):
+        return self._extract_when_missing
+
+    @extract_when_missing.setter
+    def extract_when_missing(self, extract_when_missing):
+        self._extract_when_missing = extract_when_missing
+
+    @extract_when_missing.deleter
+    def extract_when_missing(self):
+        self._extract_when_missing = None
 
     @property
     def length(self):

--- a/citrination_client/search/pif/query/core/base_object_query.py
+++ b/citrination_client/search/pif/query/core/base_object_query.py
@@ -7,13 +7,16 @@ class BaseObjectQuery(Serializable):
     Base class for all PIF object queries.
     """
 
-    def __init__(self, logic=None, extract_as=None, extract_all=None, tags=None, length=None, offset=None):
+    def __init__(self, logic=None, extract_as=None, extract_all=None, extract_when_missing=None, tags=None,
+                 length=None, offset=None):
         """
         Constructor.
 
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
@@ -24,6 +27,8 @@ class BaseObjectQuery(Serializable):
         self.extract_as = extract_as
         self._extract_all = None
         self.extract_all = extract_all
+        self._extract_when_missing = None
+        self.extract_when_missing = extract_when_missing
         self._tags = None
         self.tags = tags
         self._length = None
@@ -54,6 +59,18 @@ class BaseObjectQuery(Serializable):
     @extract_as.deleter
     def extract_as(self):
         self._extract_as = None
+
+    @property
+    def extract_when_missing(self):
+        return self._extract_when_missing
+
+    @extract_when_missing.setter
+    def extract_when_missing(self, extract_when_missing):
+        self._extract_when_missing = extract_when_missing
+
+    @extract_when_missing.deleter
+    def extract_when_missing(self):
+        self._extract_when_missing = None
 
     @property
     def extract_all(self):

--- a/citrination_client/search/pif/query/core/field_operation.py
+++ b/citrination_client/search/pif/query/core/field_operation.py
@@ -7,18 +7,21 @@ class FieldOperation(BaseFieldOperation):
     Class for all field queries.
     """
 
-    def __init__(self, filter=None, extract_as=None, extract_all=None, length=None, offset=None):
+    def __init__(self, filter=None, extract_as=None, extract_all=None, extract_when_missing=None,
+                 length=None, offset=None):
         """
         Constructor.
 
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param length: One or more :class:`.FieldOperation` objects against the length field.
         :param offset: One or more :class:`.FieldOperation` objects against the offset field.
         :param filter: One or more :class:`.Filter` objects against this field.
         """
-        super(FieldOperation, self).__init__(extract_as=extract_as, extract_all=extract_all, length=length,
-                                             offset=offset)
+        super(FieldOperation, self).__init__(extract_as=extract_as, extract_all=extract_all,
+                                             extract_when_missing=extract_when_missing, length=length, offset=offset)
         self._filter = None
         self.filter = filter
 

--- a/citrination_client/search/pif/query/core/file_reference_query.py
+++ b/citrination_client/search/pif/query/core/file_reference_query.py
@@ -8,7 +8,7 @@ class FileReferenceQuery(BaseObjectQuery):
     """
 
     def __init__(self, relative_path=None, mime_type=None, sha256=None, md5=None, logic=None, extract_as=None,
-                 extract_all=None, tags=None, length=None, offset=None):
+                 extract_all=None, extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -19,12 +19,15 @@ class FileReferenceQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
         super(FileReferenceQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
-                                                 tags=tags, length=length, offset=offset)
+                                                 extract_when_missing=extract_when_missing, tags=tags,
+                                                 length=length, offset=offset)
         self._relative_path = None
         self.relative_path = relative_path
         self._mime_type = None

--- a/citrination_client/search/pif/query/core/id_query.py
+++ b/citrination_client/search/pif/query/core/id_query.py
@@ -7,8 +7,8 @@ class IdQuery(BaseObjectQuery):
     Class to query against a PIF ID object.
     """
     
-    def __init__(self, name=None, value=None, logic=None, extract_as=None, extract_all=None, tags=None,
-                 length=None, offset=None):
+    def __init__(self, name=None, value=None, logic=None, extract_as=None, extract_all=None,
+                 extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
         
@@ -17,12 +17,15 @@ class IdQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
-        super(IdQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all, tags=tags,
-                                      length=length, offset=offset)
+        super(IdQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
+                                      extract_when_missing=extract_when_missing, tags=tags, length=length,
+                                      offset=offset)
         self._name = None
         self.name = name
         self._value = None

--- a/citrination_client/search/pif/query/core/name_query.py
+++ b/citrination_client/search/pif/query/core/name_query.py
@@ -8,7 +8,7 @@ class NameQuery(BaseObjectQuery):
     """
 
     def __init__(self, given=None, family=None, title=None, suffix=None, logic=None, extract_as=None,
-                 extract_all=None, tags=None, length=None, offset=None):
+                 extract_all=None, extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -19,12 +19,15 @@ class NameQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
-        super(NameQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all, tags=tags,
-                                        length=length, offset=offset)
+        super(NameQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
+                                        extract_when_missing=extract_when_missing, tags=tags, length=length,
+                                        offset=offset)
         self._given = None
         self.given = given
         self._family = None

--- a/citrination_client/search/pif/query/core/pages_query.py
+++ b/citrination_client/search/pif/query/core/pages_query.py
@@ -7,8 +7,8 @@ class PagesQuery(BaseObjectQuery):
     Class to query against a Pif Pages object.
     """
 
-    def __init__(self, start=None, end=None, logic=None, extract_as=None, extract_all=None, tags=None,
-                 length=None, offset=None):
+    def __init__(self, start=None, end=None, logic=None, extract_as=None, extract_all=None, extract_when_missing=None,
+                 tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -17,11 +17,14 @@ class PagesQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
-        super(PagesQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all, tags=tags,
+        super(PagesQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
+                                         extract_when_missing=extract_when_missing, tags=tags,
                                          length=length, offset=offset)
         self._start = None
         self.start = start

--- a/citrination_client/search/pif/query/core/process_step_query.py
+++ b/citrination_client/search/pif/query/core/process_step_query.py
@@ -8,8 +8,8 @@ class ProcessStepQuery(BaseObjectQuery):
     Class to query against a process step.
     """
 
-    def __init__(self, name=None, details=None, logic=None, extract_as=None, extract_all=None, tags=None,
-                 length=None, offset=None):
+    def __init__(self, name=None, details=None, logic=None, extract_as=None, extract_all=None,
+                 extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -18,12 +18,15 @@ class ProcessStepQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
         super(ProcessStepQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
-                                               tags=tags, length=length, offset=offset)
+                                               extract_when_missing=extract_when_missing, tags=tags, length=length,
+                                               offset=offset)
         self._name = None
         self.name = name
         self._details = None

--- a/citrination_client/search/pif/query/core/property_query.py
+++ b/citrination_client/search/pif/query/core/property_query.py
@@ -9,8 +9,8 @@ class PropertyQuery(ValueQuery):
     """
 
     def __init__(self, file=None, conditions=None, data_type=None, name=None, value=None, units=None,
-                 units_normalization=None, logic=None, extract_as=None, extract_all=None, tags=None,
-                 length=None, offset=None):
+                 units_normalization=None, logic=None, extract_as=None, extract_all=None,
+                 extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -24,13 +24,16 @@ class PropertyQuery(ValueQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
         super(PropertyQuery, self).__init__(name=name, value=value, units=units,
                                             units_normalization=units_normalization, logic=logic,
-                                            extract_as=extract_as, extract_all=extract_all, tags=tags,
+                                            extract_as=extract_as, extract_all=extract_all,
+                                            extract_when_missing=extract_when_missing, tags=tags,
                                             length=length, offset=offset)
         self._file = None
         self.file = file

--- a/citrination_client/search/pif/query/core/quantity_query.py
+++ b/citrination_client/search/pif/query/core/quantity_query.py
@@ -9,7 +9,7 @@ class QuantityQuery(BaseObjectQuery):
 
     def __init__(self, actual_mass_percent=None, actual_volume_percent=None, actual_number_percent=None,
                  ideal_mass_percent=None, ideal_volume_percent=None, ideal_number_percent=None, logic=None,
-                 extract_as=None, extract_all=None, tags=None, length=None, offset=None):
+                 extract_as=None, extract_all=None, extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -28,12 +28,15 @@ class QuantityQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
         super(QuantityQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
-                                            tags=tags, length=length, offset=offset)
+                                            extract_when_missing=extract_when_missing, tags=tags, length=length,
+                                            offset=offset)
         self._actual_mass_percent = None
         self.actual_mass_percent = actual_mass_percent
         self._actual_volume_percent = None

--- a/citrination_client/search/pif/query/core/reference_query.py
+++ b/citrination_client/search/pif/query/core/reference_query.py
@@ -12,7 +12,7 @@ class ReferenceQuery(BaseObjectQuery):
     def __init__(self, doi=None, isbn=None, issn=None, url=None, title=None, publisher=None, journal=None,
                  volume=None, issue=None, year=None, pages=None, authors=None, editors=None, affiliations=None,
                  acknowledgements=None, references=None, logic=None, extract_as=None, extract_all=None,
-                 tags=None, length=None, offset=None):
+                 extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -35,12 +35,15 @@ class ReferenceQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
         super(ReferenceQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
-                                             tags=tags, length=length, offset=offset)
+                                             extract_when_missing=extract_when_missing, tags=tags, length=length,
+                                             offset=offset)
         self._doi = None
         self.doi = doi
         self._isbn = None

--- a/citrination_client/search/pif/query/core/source_query.py
+++ b/citrination_client/search/pif/query/core/source_query.py
@@ -8,7 +8,7 @@ class SourceQuery(BaseObjectQuery):
     """
 
     def __init__(self, producer=None, url=None, logic=None, extract_as=None, extract_all=None,
-                 tags=None, length=None, offset=None):
+                 extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -17,12 +17,15 @@ class SourceQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
         super(SourceQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
-                                          tags=tags, length=length, offset=offset)
+                                          extract_when_missing=extract_when_missing, tags=tags, length=length,
+                                          offset=offset)
         self._producer = None
         self.producer = producer
         self._url = None

--- a/citrination_client/search/pif/query/core/system_query.py
+++ b/citrination_client/search/pif/query/core/system_query.py
@@ -16,7 +16,7 @@ class SystemQuery(BaseObjectQuery):
 
     def __init__(self, names=None, ids=None, source=None, quantity=None, chemical_formula=None, composition=None,
                  properties=None, preparation=None, references=None, sub_systems=None, logic=None, extract_as=None,
-                 extract_all=None, tags=None, length=None, offset=None):
+                 extract_all=None, extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -34,12 +34,15 @@ class SystemQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
         super(SystemQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
-                                          tags=tags, length=length, offset=offset)
+                                          extract_when_missing=extract_when_missing, tags=tags, length=length,
+                                          offset=offset)
         self._names = None
         self.names = names
         self._ids = None

--- a/citrination_client/search/pif/query/core/value_query.py
+++ b/citrination_client/search/pif/query/core/value_query.py
@@ -9,7 +9,7 @@ class ValueQuery(BaseObjectQuery):
     """
 
     def __init__(self, name=None, value=None, units=None, units_normalization=None, logic=None, extract_as=None,
-                 extract_all=None, tags=None, length=None, offset=None):
+                 extract_all=None, extract_when_missing=None, tags=None, length=None, offset=None):
         """
         Constructor.
 
@@ -20,11 +20,14 @@ class ValueQuery(BaseObjectQuery):
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
         :param tags: One or more :class:`FieldOperation` operations against the tags field.
         :param length: One or more :class:`FieldOperation` operations against the length field.
         :param offset: One or more :class:`FieldOperation` operations against the offset field.
         """
-        super(ValueQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all, tags=tags,
+        super(ValueQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
+                                         extract_when_missing=extract_when_missing, tags=tags,
                                          length=length, offset=offset)
         self._name = None
         self.name = name

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='1.2.6',
+      version='1.2.7',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(),


### PR DESCRIPTION
@maxhutch This adds support for a new field we are putting into the query language - extractWhenMissing.

The idea with this field is to provide a default value to return under extractAs when a particular part of the query does not match, but the overall query does. For example, imagine that you are querying for hardness and want to pull out the temperature for that measurement if it exists in the record. This lets you provide a default value to return for the temperature in the case that it does not exist in the record.