### PR TITLE
Deprecate FieldOperation in favor of FieldQuery and version to 1.3.0

### DIFF
--- a/citrination_client/search/pif/query/__init__.py
+++ b/citrination_client/search/pif/query/__init__.py
@@ -1,6 +1,7 @@
 from citrination_client.search.pif.query.pif_query import PifQuery
 from citrination_client.search.pif.query.core.classification_query import ClassificationQuery
 from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 from citrination_client.search.pif.query.core.file_reference_query import FileReferenceQuery
 from citrination_client.search.pif.query.core.filter import Filter
 from citrination_client.search.pif.query.core.id_query import IdQuery
@@ -16,5 +17,6 @@ from citrination_client.search.pif.query.core.system_query import SystemQuery
 from citrination_client.search.pif.query.core.units_normalization import UnitsNormalization
 from citrination_client.search.pif.query.core.value_query import ValueQuery
 from citrination_client.search.pif.query.chemical.chemical_field_operation import ChemicalFieldOperation
+from citrination_client.search.pif.query.chemical.chemical_field_query import ChemicalFieldQuery
 from citrination_client.search.pif.query.chemical.chemical_filter import ChemicalFilter
 from citrination_client.search.pif.query.chemical.composition_query import CompositionQuery

--- a/citrination_client/search/pif/query/chemical/chemical_field_operation.py
+++ b/citrination_client/search/pif/query/chemical/chemical_field_operation.py
@@ -1,39 +1,22 @@
-from citrination_client.search.pif.query.chemical.chemical_filter import ChemicalFilter
-from citrination_client.search.pif.query.core.base_field_operation import BaseFieldOperation
+from citrination_client.search.pif.query.chemical.chemical_field_query import ChemicalFieldQuery
 
 
-class ChemicalFieldOperation(BaseFieldOperation):
+def ChemicalFieldOperation(filter=None, extract_as=None, extract_all=None, extract_when_missing=None,
+                           length=None, offset=None):
     """
-    Class for all field operations against chemical information.
+    Generate a new :class:`.ChemicalFieldQuery` object.
+
+    :param filter: One or more :class:`.ChemicalFilter` objects for the query.
+    :param extract_as: String with the alias to save this field under.
+    :param extract_all: Boolean setting whether all values in an array should be extracted.
+    :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+    is missing that should be extracted (and the overall query is still satisfied).
+    :param length: One or more :class:`.FieldOperation` objects against the length field.
+    :param offset: One or more :class:`.FieldOperation` objects against the offset field.
+    :param filter: One or more :class:`.ChemicalFilter` objects against this field.
     """
+    from warnings import warn
+    warn("ChemicalFieldOperation has been deprecated in favor of ChemicalFieldQuery starting with version 1.3.0")
+    return ChemicalFieldQuery(filter=filter, extract_as=extract_as, extract_all=extract_all,
+                              extract_when_missing=extract_when_missing, length=length, offset=offset)
 
-    def __init__(self, filter=None, extract_as=None, extract_all=None, extract_when_missing=None,
-                 length=None, offset=None):
-        """
-        Constructor.
-
-        :param extract_as: String with the alias to save this field under.
-        :param extract_all: Boolean setting whether all values in an array should be extracted.
-        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
-        is missing that should be extracted (and the overall query is still satisfied).
-        :param length: One or more :class:`.FieldOperation` objects against the length field.
-        :param offset: One or more :class:`.FieldOperation` objects against the offset field.
-        :param filter: One or more :class:`.ChemicalFilter` objects against this field.
-        """
-        super(ChemicalFieldOperation, self).__init__(extract_as=extract_as, extract_all=extract_all,
-                                                     extract_when_missing=extract_when_missing, length=length,
-                                                     offset=offset)
-        self._filter = None
-        self.filter = filter
-
-    @property
-    def filter(self):
-        return self._filter
-
-    @filter.setter
-    def filter(self, filter):
-        self._filter = self._get_object(ChemicalFilter, filter)
-
-    @filter.deleter
-    def filter(self):
-        self._filter = None

--- a/citrination_client/search/pif/query/chemical/chemical_field_query.py
+++ b/citrination_client/search/pif/query/chemical/chemical_field_query.py
@@ -1,0 +1,41 @@
+from citrination_client.search.pif.query.chemical.chemical_filter import ChemicalFilter
+from citrination_client.search.pif.query.core.base_field_query import BaseFieldQuery
+
+
+class ChemicalFieldQuery(BaseFieldQuery):
+    """
+    Class for all field operations against chemical information.
+    """
+
+    def __init__(self, filter=None, logic=None, extract_as=None, extract_all=None, extract_when_missing=None,
+                 length=None, offset=None):
+        """
+        Constructor.
+
+        :param filter: One or more :class:`.ChemicalFilter` objects for the query.
+        :param logic: Logic for this query. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
+        :param extract_as: String with the alias to save this field under.
+        :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
+        :param length: One or more :class:`.FieldOperation` objects against the length field.
+        :param offset: One or more :class:`.FieldOperation` objects against the offset field.
+        :param filter: One or more :class:`.ChemicalFilter` objects against this field.
+        """
+        super(ChemicalFieldQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
+                                                 extract_when_missing=extract_when_missing, length=length,
+                                                 offset=offset)
+        self._filter = None
+        self.filter = filter
+
+    @property
+    def filter(self):
+        return self._filter
+
+    @filter.setter
+    def filter(self, filter):
+        self._filter = self._get_object(ChemicalFilter, filter)
+
+    @filter.deleter
+    def filter(self):
+        self._filter = None

--- a/citrination_client/search/pif/query/chemical/composition_query.py
+++ b/citrination_client/search/pif/query/chemical/composition_query.py
@@ -1,6 +1,6 @@
-from citrination_client.search.pif.query.chemical.chemical_field_operation import ChemicalFieldOperation
+from citrination_client.search.pif.query.chemical.chemical_field_query import ChemicalFieldQuery
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class CompositionQuery(BaseObjectQuery):
@@ -14,23 +14,23 @@ class CompositionQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param element: One or more :class:`ChemicalFieldOperation` operations against the element field.
-        :param actual_weight_percent: One or more :class:`FieldOperation` operations against the actual
+        :param element: One or more :class:`ChemicalFieldQuery` operations against the element field.
+        :param actual_weight_percent: One or more :class:`FieldQuery` operations against the actual
         weight percent field.
-        :param actual_atomic_percent: One or more :class:`FieldOperation` operations against the actual
+        :param actual_atomic_percent: One or more :class:`FieldQuery` operations against the actual
         atomic percent field.
-        :param ideal_weight_percent: One or more :class:`FieldOperation` operations against the ideal
+        :param ideal_weight_percent: One or more :class:`FieldQuery` operations against the ideal
         weight percent field.
-        :param ideal_atomic_percent: One or more :class:`FieldOperation` operations against the ideal
+        :param ideal_atomic_percent: One or more :class:`FieldQuery` operations against the ideal
         atomic percent field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(CompositionQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                                extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -52,7 +52,7 @@ class CompositionQuery(BaseObjectQuery):
 
     @element.setter
     def element(self, element):
-        self._element = self._get_object(ChemicalFieldOperation, element)
+        self._element = self._get_object(ChemicalFieldQuery, element)
 
     @element.deleter
     def element(self):
@@ -64,7 +64,7 @@ class CompositionQuery(BaseObjectQuery):
 
     @actual_weight_percent.setter
     def actual_weight_percent(self, actual_weight_percent):
-        self._actual_weight_percent = self._get_object(FieldOperation, actual_weight_percent)
+        self._actual_weight_percent = self._get_object(FieldQuery, actual_weight_percent)
 
     @actual_weight_percent.deleter
     def actual_weight_percent(self):
@@ -76,7 +76,7 @@ class CompositionQuery(BaseObjectQuery):
 
     @actual_atomic_percent.setter
     def actual_atomic_percent(self, actual_atomic_percent):
-        self._actual_atomic_percent = self._get_object(FieldOperation, actual_atomic_percent)
+        self._actual_atomic_percent = self._get_object(FieldQuery, actual_atomic_percent)
 
     @actual_atomic_percent.deleter
     def actual_atomic_percent(self):
@@ -88,7 +88,7 @@ class CompositionQuery(BaseObjectQuery):
 
     @ideal_weight_percent.setter
     def ideal_weight_percent(self, ideal_weight_percent):
-        self._ideal_weight_percent = self._get_object(FieldOperation, ideal_weight_percent)
+        self._ideal_weight_percent = self._get_object(FieldQuery, ideal_weight_percent)
 
     @ideal_weight_percent.deleter
     def ideal_weight_percent(self):
@@ -100,7 +100,7 @@ class CompositionQuery(BaseObjectQuery):
 
     @ideal_atomic_percent.setter
     def ideal_atomic_percent(self, ideal_atomic_percent):
-        self._ideal_atomic_percent = self._get_object(FieldOperation, ideal_atomic_percent)
+        self._ideal_atomic_percent = self._get_object(FieldQuery, ideal_atomic_percent)
 
     @ideal_atomic_percent.deleter
     def ideal_atomic_percent(self):

--- a/citrination_client/search/pif/query/core/base_field_operation.py
+++ b/citrination_client/search/pif/query/core/base_field_operation.py
@@ -1,91 +1,18 @@
-from pypif.util.serializable import Serializable
+from citrination_client.search.pif.query.core.base_field_query import BaseFieldQuery
 
 
-class BaseFieldOperation(Serializable):
+def BaseFieldOperation(extract_as=None, extract_all=None, extract_when_missing=None, length=None, offset=None):
     """
-    Base class for all field operations.
+    Generate a new :class:`.BaseFieldQuery` object.
+
+    :param extract_as: String with the alias to save this field under.
+    :param extract_all: Boolean setting whether all values in an array should be extracted.
+    :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+    is missing that should be extracted (and the overall query is still satisfied).
+    :param length: One or more :class:`.FieldQuery` operations against the length field.
+    :param offset: One or more :class:`.FieldQuery` operations against the offset field.
     """
-
-    def __init__(self, extract_as=None, extract_all=None, extract_when_missing=None, length=None, offset=None):
-        """
-        Constructor.
-
-        :param extract_as: String with the alias to save this field under.
-        :param extract_all: Boolean setting whether all values in an array should be extracted.
-        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
-        is missing that should be extracted (and the overall query is still satisfied).
-        :param length: One or more :class:`.FieldOperation` operations against the length field.
-        :param offset: One or more :class:`.FieldOperation` operations against the offset field.
-        """
-        self._extract_as = None
-        self.extract_as = extract_as
-        self._extract_all = None
-        self.extract_all = extract_all
-        self._extract_when_missing = None
-        self.extract_when_missing = extract_when_missing
-        self._length = None
-        self.length = length
-        self._offset = None
-        self.offset = offset
-
-    @property
-    def extract_as(self):
-        return self._extract_as
-
-    @extract_as.setter
-    def extract_as(self, extract_as):
-        self._extract_as = extract_as
-
-    @extract_as.deleter
-    def extract_as(self):
-        self._extract_as = None
-
-    @property
-    def extract_all(self):
-        return self._extract_all
-
-    @extract_all.setter
-    def extract_all(self, extract_all):
-        self._extract_all = extract_all
-
-    @extract_all.deleter
-    def extract_all(self):
-        self._extract_all = None
-
-    @property
-    def extract_when_missing(self):
-        return self._extract_when_missing
-
-    @extract_when_missing.setter
-    def extract_when_missing(self, extract_when_missing):
-        self._extract_when_missing = extract_when_missing
-
-    @extract_when_missing.deleter
-    def extract_when_missing(self):
-        self._extract_when_missing = None
-
-    @property
-    def length(self):
-        return self._length
-
-    @length.setter
-    def length(self, length):
-        from citrination_client.search.pif.query.core.field_operation import FieldOperation
-        self._length = self._get_object(FieldOperation, length)
-
-    @length.deleter
-    def length(self):
-        self._length = None
-
-    @property
-    def offset(self):
-        return self._offset
-
-    @offset.setter
-    def offset(self, offset):
-        from citrination_client.search.pif.query.core.field_operation import FieldOperation
-        self._offset = self._get_object(FieldOperation, offset)
-
-    @offset.deleter
-    def offset(self):
-        self._offset = None
+    from warnings import warn
+    warn("BaseFieldOperation has been deprecated in favor of BaseFieldQuery starting with version 1.3.0")
+    return BaseFieldQuery(extract_as=extract_as, extract_all=extract_all, extract_when_missing=extract_when_missing,
+                          length=length, offset=offset)

--- a/citrination_client/search/pif/query/core/base_field_query.py
+++ b/citrination_client/search/pif/query/core/base_field_query.py
@@ -1,25 +1,23 @@
 from pypif.util.serializable import Serializable
-from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
-class BaseObjectQuery(Serializable):
+class BaseFieldQuery(Serializable):
     """
-    Base class for all PIF object queries.
+    Base class for all field queries.
     """
 
-    def __init__(self, logic=None, extract_as=None, extract_all=None, extract_when_missing=None, tags=None,
+    def __init__(self, logic=None, extract_as=None, extract_all=None, extract_when_missing=None,
                  length=None, offset=None):
         """
         Constructor.
 
-        :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
+        :param logic: Logic for this query. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldQuery` operations against the tags field.
-        :param length: One or more :class:`FieldQuery` operations against the length field.
-        :param offset: One or more :class:`FieldQuery` operations against the offset field.
+        :param length: One or more :class:`.FieldQuery` operations against the length field.
+        :param offset: One or more :class:`.FieldQuery` operations against the offset field.
         """
         self._logic = None
         self.logic = logic
@@ -29,8 +27,6 @@ class BaseObjectQuery(Serializable):
         self.extract_all = extract_all
         self._extract_when_missing = None
         self.extract_when_missing = extract_when_missing
-        self._tags = None
-        self.tags = tags
         self._length = None
         self.length = length
         self._offset = None
@@ -61,18 +57,6 @@ class BaseObjectQuery(Serializable):
         self._extract_as = None
 
     @property
-    def extract_when_missing(self):
-        return self._extract_when_missing
-
-    @extract_when_missing.setter
-    def extract_when_missing(self, extract_when_missing):
-        self._extract_when_missing = extract_when_missing
-
-    @extract_when_missing.deleter
-    def extract_when_missing(self):
-        self._extract_when_missing = None
-
-    @property
     def extract_all(self):
         return self._extract_all
 
@@ -85,16 +69,16 @@ class BaseObjectQuery(Serializable):
         self._extract_all = None
 
     @property
-    def tags(self):
-        return self._tags
+    def extract_when_missing(self):
+        return self._extract_when_missing
 
-    @tags.setter
-    def tags(self, tags):
-        self._tags = self._get_object(FieldQuery, tags)
+    @extract_when_missing.setter
+    def extract_when_missing(self, extract_when_missing):
+        self._extract_when_missing = extract_when_missing
 
-    @tags.deleter
-    def tags(self):
-        self._tags = None
+    @extract_when_missing.deleter
+    def extract_when_missing(self):
+        self._extract_when_missing = None
 
     @property
     def length(self):
@@ -102,6 +86,7 @@ class BaseObjectQuery(Serializable):
 
     @length.setter
     def length(self, length):
+        from citrination_client.search.pif.query.core.field_query import FieldQuery
         self._length = self._get_object(FieldQuery, length)
 
     @length.deleter
@@ -114,6 +99,7 @@ class BaseObjectQuery(Serializable):
 
     @offset.setter
     def offset(self, offset):
+        from citrination_client.search.pif.query.core.field_query import FieldQuery
         self._offset = self._get_object(FieldQuery, offset)
 
     @offset.deleter

--- a/citrination_client/search/pif/query/core/classification_query.py
+++ b/citrination_client/search/pif/query/core/classification_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class ClassificationQuery(BaseObjectQuery):
@@ -12,16 +12,16 @@ class ClassificationQuery(BaseObjectQuery):
         """
         Constructor.
         
-        :param name: One or more :class:`FieldOperation` operations against the name field.
-        :param value: One or more :class:`FieldOperation` operations against the value field.
+        :param name: One or more :class:`FieldQuery` operations against the name field.
+        :param value: One or more :class:`FieldQuery` operations against the value field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(ClassificationQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                                   extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -37,7 +37,7 @@ class ClassificationQuery(BaseObjectQuery):
     
     @name.setter
     def name(self, name):
-        self._get_object(FieldOperation, name)
+        self._get_object(FieldQuery, name)
     
     @name.deleter
     def name(self):
@@ -49,7 +49,7 @@ class ClassificationQuery(BaseObjectQuery):
 
     @value.setter
     def value(self, value):
-        self._get_object(FieldOperation, value)
+        self._get_object(FieldQuery, value)
 
     @value.deleter
     def value(self):

--- a/citrination_client/search/pif/query/core/field_operation.py
+++ b/citrination_client/search/pif/query/core/field_operation.py
@@ -1,38 +1,21 @@
-from citrination_client.search.pif.query.core.base_field_operation import BaseFieldOperation
-from citrination_client.search.pif.query.core.filter import Filter
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
-class FieldOperation(BaseFieldOperation):
+def FieldOperation(filter=None, extract_as=None, extract_all=None, extract_when_missing=None,
+                   length=None, offset=None):
     """
-    Class for all field queries.
+    Generate a new :class:`.FieldQuery` object.
+
+    :param filter: One or more :class:`.Filter` objects for the query.
+    :param extract_as: String with the alias to save this field under.
+    :param extract_all: Boolean setting whether all values in an array should be extracted.
+    :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+    is missing that should be extracted (and the overall query is still satisfied).
+    :param length: One or more :class:`.FieldOperation` objects against the length field.
+    :param offset: One or more :class:`.FieldOperation` objects against the offset field.
+    :param filter: One or more :class:`.Filter` objects against this field.
     """
-
-    def __init__(self, filter=None, extract_as=None, extract_all=None, extract_when_missing=None,
-                 length=None, offset=None):
-        """
-        Constructor.
-
-        :param extract_as: String with the alias to save this field under.
-        :param extract_all: Boolean setting whether all values in an array should be extracted.
-        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
-        is missing that should be extracted (and the overall query is still satisfied).
-        :param length: One or more :class:`.FieldOperation` objects against the length field.
-        :param offset: One or more :class:`.FieldOperation` objects against the offset field.
-        :param filter: One or more :class:`.Filter` objects against this field.
-        """
-        super(FieldOperation, self).__init__(extract_as=extract_as, extract_all=extract_all,
-                                             extract_when_missing=extract_when_missing, length=length, offset=offset)
-        self._filter = None
-        self.filter = filter
-
-    @property
-    def filter(self):
-        return self._filter
-
-    @filter.setter
-    def filter(self, filter):
-        self._filter = self._get_object(Filter, filter)
-
-    @filter.deleter
-    def filter(self):
-        self._filter = None
+    from warnings import warn
+    warn("FieldOperation has been deprecated in favor of FieldQuery starting with version 1.3.0")
+    return FieldQuery(filter=filter, extract_as=extract_as, extract_all=extract_all,
+                      extract_when_missing=extract_when_missing, length=length, offset=offset)

--- a/citrination_client/search/pif/query/core/field_query.py
+++ b/citrination_client/search/pif/query/core/field_query.py
@@ -1,0 +1,40 @@
+from citrination_client.search.pif.query.core.base_field_query import BaseFieldQuery
+from citrination_client.search.pif.query.core.filter import Filter
+
+
+class FieldQuery(BaseFieldQuery):
+    """
+    Class for all field queries.
+    """
+
+    def __init__(self, filter=None, logic=None, extract_as=None, extract_all=None, extract_when_missing=None,
+                 length=None, offset=None):
+        """
+        Constructor.
+
+        :param filter: One or more :class:`.Filter` objects for the query.
+        :param logic: Logic for this query. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
+        :param extract_as: String with the alias to save this field under.
+        :param extract_all: Boolean setting whether all values in an array should be extracted.
+        :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
+        is missing that should be extracted (and the overall query is still satisfied).
+        :param length: One or more :class:`.FieldQuery` objects against the length field.
+        :param offset: One or more :class:`.FieldQuery` objects against the offset field.
+        :param filter: One or more :class:`.Filter` objects against this field.
+        """
+        super(FieldQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
+                                         extract_when_missing=extract_when_missing, length=length, offset=offset)
+        self._filter = None
+        self.filter = filter
+
+    @property
+    def filter(self):
+        return self._filter
+
+    @filter.setter
+    def filter(self, filter):
+        self._filter = self._get_object(Filter, filter)
+
+    @filter.deleter
+    def filter(self):
+        self._filter = None

--- a/citrination_client/search/pif/query/core/file_reference_query.py
+++ b/citrination_client/search/pif/query/core/file_reference_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class FileReferenceQuery(BaseObjectQuery):
@@ -12,18 +12,18 @@ class FileReferenceQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param relative_path: One or more :class:`FieldOperation` operations against the relative path field.
-        :param mime_type: One or more :class:`FieldOperation` operations against the mime type field.
-        :param sha256: One or more :class:`FieldOperation` operations against the sha256 field.
-        :param md5: One or more :class:`FieldOperation` operations against the md5 field.
+        :param relative_path: One or more :class:`FieldQuery` operations against the relative path field.
+        :param mime_type: One or more :class:`FieldQuery` operations against the mime type field.
+        :param sha256: One or more :class:`FieldQuery` operations against the sha256 field.
+        :param md5: One or more :class:`FieldQuery` operations against the md5 field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(FileReferenceQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                                  extract_when_missing=extract_when_missing, tags=tags,
@@ -43,7 +43,7 @@ class FileReferenceQuery(BaseObjectQuery):
 
     @relative_path.setter
     def relative_path(self, relative_path):
-        self._relative_path = self._get_object(FieldOperation, relative_path)
+        self._relative_path = self._get_object(FieldQuery, relative_path)
 
     @relative_path.deleter
     def relative_path(self):
@@ -55,7 +55,7 @@ class FileReferenceQuery(BaseObjectQuery):
 
     @mime_type.setter
     def mime_type(self, mime_type):
-        self._mime_type = self._get_object(FieldOperation, mime_type)
+        self._mime_type = self._get_object(FieldQuery, mime_type)
 
     @mime_type.deleter
     def mime_type(self):
@@ -67,7 +67,7 @@ class FileReferenceQuery(BaseObjectQuery):
 
     @sha256.setter
     def sha256(self, sha256):
-        self._sha256 = self._get_object(FieldOperation, sha256)
+        self._sha256 = self._get_object(FieldQuery, sha256)
 
     @sha256.deleter
     def sha256(self):
@@ -79,7 +79,7 @@ class FileReferenceQuery(BaseObjectQuery):
 
     @md5.setter
     def md5(self, md5):
-        self._md5 = self._get_object(FieldOperation, md5)
+        self._md5 = self._get_object(FieldQuery, md5)
 
     @md5.deleter
     def md5(self):

--- a/citrination_client/search/pif/query/core/id_query.py
+++ b/citrination_client/search/pif/query/core/id_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class IdQuery(BaseObjectQuery):
@@ -12,16 +12,16 @@ class IdQuery(BaseObjectQuery):
         """
         Constructor.
         
-        :param name: One or more :class:`FieldOperation` operations against the name field.
-        :param value: One or more :class:`FieldOperation` operations against the value field.
+        :param name: One or more :class:`FieldQuery` operations against the name field.
+        :param value: One or more :class:`FieldQuery` operations against the value field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(IdQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                       extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -37,7 +37,7 @@ class IdQuery(BaseObjectQuery):
     
     @name.setter
     def name(self, name):
-        self._get_object(FieldOperation, name)
+        self._get_object(FieldQuery, name)
     
     @name.deleter
     def name(self):
@@ -49,7 +49,7 @@ class IdQuery(BaseObjectQuery):
 
     @value.setter
     def value(self, value):
-        self._get_object(FieldOperation, value)
+        self._get_object(FieldQuery, value)
 
     @value.deleter
     def value(self):

--- a/citrination_client/search/pif/query/core/name_query.py
+++ b/citrination_client/search/pif/query/core/name_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class NameQuery(BaseObjectQuery):
@@ -12,18 +12,18 @@ class NameQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param given: One or more :class:`FieldOperation` operations against the given name field.
-        :param family: One or more :class:`FieldOperation` operations against the family name field.
-        :param title: One or more :class:`FieldOperation` operations against the title field.
-        :param suffix: One or more :class:`FieldOperation` operations against the suffix field.
+        :param given: One or more :class:`FieldQuery` operations against the given name field.
+        :param family: One or more :class:`FieldQuery` operations against the family name field.
+        :param title: One or more :class:`FieldQuery` operations against the title field.
+        :param suffix: One or more :class:`FieldQuery` operations against the suffix field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(NameQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                         extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -43,7 +43,7 @@ class NameQuery(BaseObjectQuery):
 
     @given.setter
     def given(self, given):
-        self._given = self._get_object(FieldOperation, given)
+        self._given = self._get_object(FieldQuery, given)
 
     @given.deleter
     def given(self):
@@ -55,7 +55,7 @@ class NameQuery(BaseObjectQuery):
 
     @family.setter
     def family(self, family):
-        self._family = self._get_object(FieldOperation, family)
+        self._family = self._get_object(FieldQuery, family)
 
     @family.deleter
     def family(self):
@@ -67,7 +67,7 @@ class NameQuery(BaseObjectQuery):
 
     @title.setter
     def title(self, title):
-        self._title = self._get_object(FieldOperation, title)
+        self._title = self._get_object(FieldQuery, title)
 
     @title.deleter
     def title(self):
@@ -79,7 +79,7 @@ class NameQuery(BaseObjectQuery):
 
     @suffix.setter
     def suffix(self, suffix):
-        self._suffix = self._get_object(FieldOperation, suffix)
+        self._suffix = self._get_object(FieldQuery, suffix)
 
     @suffix.deleter
     def suffix(self):

--- a/citrination_client/search/pif/query/core/pages_query.py
+++ b/citrination_client/search/pif/query/core/pages_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class PagesQuery(BaseObjectQuery):
@@ -12,16 +12,16 @@ class PagesQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param start: One or more :class:`FieldOperation` operations against the starting page field.
-        :param end: One or more :class:`FieldOperation` operations against the ending page field.
+        :param start: One or more :class:`FieldQuery` operations against the starting page field.
+        :param end: One or more :class:`FieldQuery` operations against the ending page field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(PagesQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                          extract_when_missing=extract_when_missing, tags=tags,
@@ -49,7 +49,7 @@ class PagesQuery(BaseObjectQuery):
 
     @end.setter
     def end(self, end):
-        self._end = self._get_object(FieldOperation, end)
+        self._end = self._get_object(FieldQuery, end)
 
     @end.deleter
     def end(self):

--- a/citrination_client/search/pif/query/core/process_step_query.py
+++ b/citrination_client/search/pif/query/core/process_step_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 from citrination_client.search.pif.query.core.value_query import ValueQuery
 
 
@@ -13,16 +13,16 @@ class ProcessStepQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param name: One or more :class:`FieldOperation` operations against the name field.
+        :param name: One or more :class:`FieldQuery` operations against the name field.
         :param details: One or more :class:`ValueQuery` operations against the details of the step.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(ProcessStepQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                                extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -38,7 +38,7 @@ class ProcessStepQuery(BaseObjectQuery):
 
     @name.setter
     def name(self, name):
-        self._name = self._get_object(FieldOperation, name)
+        self._name = self._get_object(FieldQuery, name)
 
     @name.deleter
     def name(self):

--- a/citrination_client/search/pif/query/core/property_query.py
+++ b/citrination_client/search/pif/query/core/property_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.value_query import ValueQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class PropertyQuery(ValueQuery):
@@ -14,20 +14,20 @@ class PropertyQuery(ValueQuery):
         Constructor.
 
         :param conditions: One or more :class:`ValueQuery` operations against the conditions.
-        :param data_type: One or more :class:`FieldOperation` operations against the dataType field.
-        :param name: One or more :class:`FieldOperation` operations against the name field.
-        :param value: One or more :class:`FieldOperation` operations against the value.
+        :param data_type: One or more :class:`FieldQuery` operations against the dataType field.
+        :param name: One or more :class:`FieldQuery` operations against the name field.
+        :param value: One or more :class:`FieldQuery` operations against the value.
         :param file: One or more :class:`FileReferenceQuery` operations against the file.
-        :param units: One or more :class:`FieldOperation` operations against the units field.
+        :param units: One or more :class:`FieldQuery` operations against the units field.
         :param units_normalization: :class:`UnitsNormalization` object for normalizing units.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(PropertyQuery, self).__init__(name=name, value=value, file=file, units=units,
                                             units_normalization=units_normalization, logic=logic,
@@ -57,7 +57,7 @@ class PropertyQuery(ValueQuery):
 
     @data_type.setter
     def data_type(self, data_type):
-        self._data_type = self._get_object(FieldOperation, data_type)
+        self._data_type = self._get_object(FieldQuery, data_type)
 
     @data_type.deleter
     def data_type(self):

--- a/citrination_client/search/pif/query/core/quantity_query.py
+++ b/citrination_client/search/pif/query/core/quantity_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class QuantityQuery(BaseObjectQuery):
@@ -13,26 +13,26 @@ class QuantityQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param actual_mass_percent: One or more :class:`FieldOperation` operations against the actual mass
+        :param actual_mass_percent: One or more :class:`FieldQuery` operations against the actual mass
         percent field.
-        :param actual_volume_percent: One or more :class:`FieldOperation` operations against the actual volume
+        :param actual_volume_percent: One or more :class:`FieldQuery` operations against the actual volume
         percent field.
-        :param actual_number_percent: One or more :class:`FieldOperation` operations against the actual number
+        :param actual_number_percent: One or more :class:`FieldQuery` operations against the actual number
         percent field.
-        :param ideal_mass_percent: One or more :class:`FieldOperation` operations against the ideal mass
+        :param ideal_mass_percent: One or more :class:`FieldQuery` operations against the ideal mass
         percent field.
-        :param ideal_volume_percent: One or more :class:`FieldOperation` operations against the ideal volume
+        :param ideal_volume_percent: One or more :class:`FieldQuery` operations against the ideal volume
         percent field.
-        :param ideal_number_percent: One or more :class:`FieldOperation` operations against the ideal number
+        :param ideal_number_percent: One or more :class:`FieldQuery` operations against the ideal number
         percent field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(QuantityQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                             extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -56,7 +56,7 @@ class QuantityQuery(BaseObjectQuery):
 
     @actual_mass_percent.setter
     def actual_mass_percent(self, actual_mass_percent):
-        self._actual_mass_percent = self._get_object(FieldOperation, actual_mass_percent)
+        self._actual_mass_percent = self._get_object(FieldQuery, actual_mass_percent)
 
     @actual_mass_percent.deleter
     def actual_mass_percent(self):
@@ -68,7 +68,7 @@ class QuantityQuery(BaseObjectQuery):
 
     @actual_volume_percent.setter
     def actual_volume_percent(self, actual_volume_percent):
-        self._actual_volume_percent = self._get_object(FieldOperation, actual_volume_percent)
+        self._actual_volume_percent = self._get_object(FieldQuery, actual_volume_percent)
 
     @actual_volume_percent.deleter
     def actual_volume_percent(self):
@@ -80,7 +80,7 @@ class QuantityQuery(BaseObjectQuery):
 
     @actual_number_percent.setter
     def actual_number_percent(self, actual_number_percent):
-        self._actual_number_percent = self._get_object(FieldOperation, actual_number_percent)
+        self._actual_number_percent = self._get_object(FieldQuery, actual_number_percent)
 
     @actual_number_percent.deleter
     def actual_number_percent(self):
@@ -92,7 +92,7 @@ class QuantityQuery(BaseObjectQuery):
 
     @ideal_mass_percent.setter
     def ideal_mass_percent(self, ideal_mass_percent):
-        self._ideal_mass_percent = self._get_object(FieldOperation, ideal_mass_percent)
+        self._ideal_mass_percent = self._get_object(FieldQuery, ideal_mass_percent)
 
     @ideal_mass_percent.deleter
     def ideal_mass_percent(self):
@@ -104,7 +104,7 @@ class QuantityQuery(BaseObjectQuery):
 
     @ideal_volume_percent.setter
     def ideal_volume_percent(self, ideal_volume_percent):
-        self._ideal_volume_percent = self._get_object(FieldOperation, ideal_volume_percent)
+        self._ideal_volume_percent = self._get_object(FieldQuery, ideal_volume_percent)
 
     @ideal_volume_percent.deleter
     def ideal_volume_percent(self):
@@ -116,7 +116,7 @@ class QuantityQuery(BaseObjectQuery):
 
     @ideal_number_percent.setter
     def ideal_number_percent(self, ideal_number_percent):
-        self._ideal_number_percent = self._get_object(FieldOperation, ideal_number_percent)
+        self._ideal_number_percent = self._get_object(FieldQuery, ideal_number_percent)
 
     @ideal_number_percent.deleter
     def ideal_number_percent(self):

--- a/citrination_client/search/pif/query/core/reference_query.py
+++ b/citrination_client/search/pif/query/core/reference_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 from citrination_client.search.pif.query.core.name_query import NameQuery
 from citrination_client.search.pif.query.core.pages_query import PagesQuery
 
@@ -16,30 +16,30 @@ class ReferenceQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param doi: One or more :class:`FieldOperation` operations against the doi field.
-        :param isbn: One or more :class:`FieldOperation` operations against the isbn field.
-        :param issn: One or more :class:`FieldOperation` operations against the issn field.
-        :param url: One or more :class:`FieldOperation` operations against the url field.
-        :param title: One or more :class:`FieldOperation` operations against the title field.
-        :param publisher: One or more :class:`FieldOperation` operations against the publisher field.
-        :param journal: One or more :class:`FieldOperation` operations against the journal field.
-        :param volume: One or more :class:`FieldOperation` operations against the volume field.
-        :param issue: One or more :class:`FieldOperation` operations against the issue field.
-        :param year: One or more :class:`FieldOperation` operations against the year field.
+        :param doi: One or more :class:`FieldQuery` operations against the doi field.
+        :param isbn: One or more :class:`FieldQuery` operations against the isbn field.
+        :param issn: One or more :class:`FieldQuery` operations against the issn field.
+        :param url: One or more :class:`FieldQuery` operations against the url field.
+        :param title: One or more :class:`FieldQuery` operations against the title field.
+        :param publisher: One or more :class:`FieldQuery` operations against the publisher field.
+        :param journal: One or more :class:`FieldQuery` operations against the journal field.
+        :param volume: One or more :class:`FieldQuery` operations against the volume field.
+        :param issue: One or more :class:`FieldQuery` operations against the issue field.
+        :param year: One or more :class:`FieldQuery` operations against the year field.
         :param pages: One or more :class:`PagesQuery` operations against the pages field.
         :param authors: One or more :class:`NameQuery` operations against the authors field.
         :param editors: One or more :class:`NameQuery` operations against the editors field.
-        :param affiliations: One or more :class:`FieldOperation` operations against the affiliations field.
-        :param acknowledgements: One or more :class:`FieldOperation` operations against the acknowledgements field.
+        :param affiliations: One or more :class:`FieldQuery` operations against the affiliations field.
+        :param acknowledgements: One or more :class:`FieldQuery` operations against the acknowledgements field.
         :param references: One or more :class:`ReferenceQuery` operations against the references field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(ReferenceQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                              extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -83,7 +83,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @doi.setter
     def doi(self, doi):
-        self._doi = self._get_object(FieldOperation, doi)
+        self._doi = self._get_object(FieldQuery, doi)
 
     @doi.deleter
     def doi(self):
@@ -95,7 +95,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @isbn.setter
     def isbn(self, isbn):
-        self._isbn = self._get_object(FieldOperation, isbn)
+        self._isbn = self._get_object(FieldQuery, isbn)
 
     @isbn.deleter
     def isbn(self):
@@ -107,7 +107,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @issn.setter
     def issn(self, issn):
-        self._issn = self._get_object(FieldOperation, issn)
+        self._issn = self._get_object(FieldQuery, issn)
 
     @issn.deleter
     def issn(self):
@@ -119,7 +119,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @url.setter
     def url(self, url):
-        self._url = self._get_object(FieldOperation, url)
+        self._url = self._get_object(FieldQuery, url)
 
     @url.deleter
     def url(self):
@@ -131,7 +131,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @title.setter
     def title(self, title):
-        self._title = self._get_object(FieldOperation, title)
+        self._title = self._get_object(FieldQuery, title)
 
     @title.deleter
     def title(self):
@@ -143,7 +143,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @publisher.setter
     def publisher(self, publisher):
-        self._publisher = self._get_object(FieldOperation, publisher)
+        self._publisher = self._get_object(FieldQuery, publisher)
 
     @publisher.deleter
     def publisher(self):
@@ -155,7 +155,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @journal.setter
     def journal(self, journal):
-        self._journal = self._get_object(FieldOperation, journal)
+        self._journal = self._get_object(FieldQuery, journal)
 
     @journal.deleter
     def journal(self):
@@ -167,7 +167,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @volume.setter
     def volume(self, volume):
-        self._volume = self._get_object(FieldOperation, volume)
+        self._volume = self._get_object(FieldQuery, volume)
 
     @volume.deleter
     def volume(self):
@@ -179,7 +179,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @issue.setter
     def issue(self, issue):
-        self._issue = self._get_object(FieldOperation, issue)
+        self._issue = self._get_object(FieldQuery, issue)
 
     @issue.deleter
     def issue(self):
@@ -191,7 +191,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @year.setter
     def year(self, year):
-        self._year = self._get_object(FieldOperation, year)
+        self._year = self._get_object(FieldQuery, year)
 
     @year.deleter
     def year(self):
@@ -239,7 +239,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @affiliations.setter
     def affiliations(self, affiliations):
-        self._affiliations = self._get_object(FieldOperation, affiliations)
+        self._affiliations = self._get_object(FieldQuery, affiliations)
 
     @affiliations.deleter
     def affiliations(self):
@@ -251,7 +251,7 @@ class ReferenceQuery(BaseObjectQuery):
 
     @acknowledgements.setter
     def acknowledgements(self, acknowledgements):
-        self._acknowledgements = self._get_object(FieldOperation, acknowledgements)
+        self._acknowledgements = self._get_object(FieldQuery, acknowledgements)
 
     @acknowledgements.deleter
     def acknowledgements(self):

--- a/citrination_client/search/pif/query/core/source_query.py
+++ b/citrination_client/search/pif/query/core/source_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 
 
 class SourceQuery(BaseObjectQuery):
@@ -12,16 +12,16 @@ class SourceQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param producer: One or more :class:`FieldOperation` operations against the producer field.
-        :param url: One or more :class:`FieldOperation` operations against the url field.
+        :param producer: One or more :class:`FieldQuery` operations against the producer field.
+        :param url: One or more :class:`FieldQuery` operations against the url field.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(SourceQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                           extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -37,7 +37,7 @@ class SourceQuery(BaseObjectQuery):
 
     @producer.setter
     def producer(self, producer):
-        self._producer = self._get_object(FieldOperation, producer)
+        self._producer = self._get_object(FieldQuery, producer)
 
     @producer.deleter
     def producer(self):
@@ -49,7 +49,7 @@ class SourceQuery(BaseObjectQuery):
 
     @url.setter
     def url(self, url):
-        self._url = self._get_object(FieldOperation, url)
+        self._url = self._get_object(FieldQuery, url)
 
     @url.deleter
     def url(self):

--- a/citrination_client/search/pif/query/core/system_query.py
+++ b/citrination_client/search/pif/query/core/system_query.py
@@ -1,13 +1,13 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
 from citrination_client.search.pif.query.core.classification_query import ClassificationQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 from citrination_client.search.pif.query.core.id_query import IdQuery
 from citrination_client.search.pif.query.core.process_step_query import ProcessStepQuery
 from citrination_client.search.pif.query.core.property_query import PropertyQuery
 from citrination_client.search.pif.query.core.quantity_query import QuantityQuery
 from citrination_client.search.pif.query.core.reference_query import ReferenceQuery
 from citrination_client.search.pif.query.core.source_query import SourceQuery
-from citrination_client.search.pif.query.chemical.chemical_field_operation import ChemicalFieldOperation
+from citrination_client.search.pif.query.chemical.chemical_field_query import ChemicalFieldQuery
 from citrination_client.search.pif.query.chemical.composition_query import CompositionQuery
 
 
@@ -22,12 +22,12 @@ class SystemQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param names: One or more :class:`FieldOperation` operations against the names field.
+        :param names: One or more :class:`FieldQuery` operations against the names field.
         :param ids: One or more :class:`IdQuery` operations against the ids field.
         :param classifications: One or more :class:`ClassificationQuery` operations against the classifications field.
         :param source: One or more :class:`SourceQuery` operations against the source field.
         :param quantity: One or more :class:`QuantityQuery` operations against the quantity field.
-        :param chemical_formula: One or more :class:`ChemicalFieldOperation` operations against the
+        :param chemical_formula: One or more :class:`ChemicalFieldQuery` operations against the
         chemical formula field.
         :param composition: One or more :class:`CompositionQuery` operations against the composition field.
         :param properties: One or more :class:`PropertyQuery` operations against the properties field.
@@ -39,9 +39,9 @@ class SystemQuery(BaseObjectQuery):
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(SystemQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                           extract_when_missing=extract_when_missing, tags=tags, length=length,
@@ -75,7 +75,7 @@ class SystemQuery(BaseObjectQuery):
 
     @names.setter
     def names(self, names):
-        self._names = self._get_object(FieldOperation, names)
+        self._names = self._get_object(FieldQuery, names)
 
     @names.deleter
     def names(self):
@@ -135,7 +135,7 @@ class SystemQuery(BaseObjectQuery):
 
     @chemical_formula.setter
     def chemical_formula(self, chemical_formula):
-        self._chemical_formula = self._get_object(ChemicalFieldOperation, chemical_formula)
+        self._chemical_formula = self._get_object(ChemicalFieldQuery, chemical_formula)
 
     @chemical_formula.deleter
     def chemical_formula(self):

--- a/citrination_client/search/pif/query/core/value_query.py
+++ b/citrination_client/search/pif/query/core/value_query.py
@@ -1,5 +1,5 @@
 from citrination_client.search.pif.query.core.base_object_query import BaseObjectQuery
-from citrination_client.search.pif.query.core.field_operation import FieldOperation
+from citrination_client.search.pif.query.core.field_query import FieldQuery
 from citrination_client.search.pif.query.core.file_reference_query import FileReferenceQuery
 from citrination_client.search.pif.query.core.units_normalization import UnitsNormalization
 
@@ -14,19 +14,19 @@ class ValueQuery(BaseObjectQuery):
         """
         Constructor.
 
-        :param name: One or more :class:`FieldOperation` operations against the name field.
-        :param value: One or more :class:`FieldOperation` operations against the value.
+        :param name: One or more :class:`FieldQuery` operations against the name field.
+        :param value: One or more :class:`FieldQuery` operations against the value.
         :param file: One or more :class:`FileReferenceQuery` operations against the file.
-        :param units: One or more :class:`FieldOperation` operations against the units field.
+        :param units: One or more :class:`FieldQuery` operations against the units field.
         :param units_normalization: :class:`UnitsNormalization` object for normalizing units.
         :param logic: Logic for this filter. Must be equal to one of "MUST", "MUST_NOT", "SHOULD", or "OPTIONAL".
         :param extract_as: String with the alias to save this field under.
         :param extract_all: Boolean setting whether all values in an array should be extracted.
         :param extract_when_missing: Any valid JSON-supported object or PIF object. This value is returned when a value
         is missing that should be extracted (and the overall query is still satisfied).
-        :param tags: One or more :class:`FieldOperation` operations against the tags field.
-        :param length: One or more :class:`FieldOperation` operations against the length field.
-        :param offset: One or more :class:`FieldOperation` operations against the offset field.
+        :param tags: One or more :class:`FieldQuery` operations against the tags field.
+        :param length: One or more :class:`FieldQuery` operations against the length field.
+        :param offset: One or more :class:`FieldQuery` operations against the offset field.
         """
         super(ValueQuery, self).__init__(logic=logic, extract_as=extract_as, extract_all=extract_all,
                                          extract_when_missing=extract_when_missing, tags=tags,
@@ -48,7 +48,7 @@ class ValueQuery(BaseObjectQuery):
 
     @name.setter
     def name(self, name):
-        self._name = self._get_object(FieldOperation, name)
+        self._name = self._get_object(FieldQuery, name)
 
     @name.deleter
     def name(self):
@@ -60,7 +60,7 @@ class ValueQuery(BaseObjectQuery):
 
     @value.setter
     def value(self, value):
-        self._value = self._get_object(FieldOperation, value)
+        self._value = self._get_object(FieldQuery, value)
 
     @value.deleter
     def value(self):
@@ -84,7 +84,7 @@ class ValueQuery(BaseObjectQuery):
 
     @units.setter
     def units(self, units):
-        self._units = self._get_object(FieldOperation, units)
+        self._units = self._get_object(FieldQuery, units)
 
     @units.deleter
     def units(self):


### PR DESCRIPTION
@maxhutch This looks like a lot, but it just deprecates FieldOperation and ChemicalFieldOperation in favor of FieldQuery and ChemicalFieldQuery. This is more consistent with the naming throughout the rest of the query language. 

Backwards compatibility is maintained through e.g. https://github.com/CitrineInformatics/python-citrination-client/blob/d98a517a8b5fe588ee2e6f33fc3f895af0d02494/citrination_client/search/pif/query/core/field_operation.py. 

Are we we merging into develop or master? Let me know if it's the former and I will close this and open a new PR.