### PR TITLE
Add Necessary Headers To Upload PUT Requests to S3

### DIFF
--- a/citrination_client/client.py
+++ b/citrination_client/client.py
@@ -32,7 +32,7 @@ class CitrinationClient(object):
         https://citrination.com. This should point to the full url of the site to access. For example, to access
         the STEEL site on citrination, use 'https://STEEL.citrination.com'.
         """
-        self.headers = {'X-API-Key': quote(api_key), 'Content-Type': 'application/json'}
+        self.headers = {'X-API-Key': quote(api_key), 'Content-Type': 'application/json', 'X-Citrination-API-Version': '1.0.0'}
         self.api_url = site + '/api'
         self.pif_search_url = self.api_url + '/search/pif_search'
         self.pif_multi_search_url = self.api_url + '/search/pif_multi_search'
@@ -269,7 +269,7 @@ class CitrinationClient(object):
                 j = json.loads(r.content.decode('utf-8'))
                 s3url = self._get_s3_presigned_url(j)
                 with open(source_path, 'rb') as f:
-                    r = requests.put(s3url, data=f, headers=self._upload_put_url_headers())
+                    r = requests.put(s3url, data=f, headers=j["required_headers"])
                     if r.status_code == 200:
                         url_data = {'s3object': j['url']['path'], 's3bucket': j['bucket']}
                         requests.post(self._get_update_file_upload_url(j['file_id']),
@@ -303,18 +303,6 @@ class CitrinationClient(object):
         :return: Response object or return code if the file was not uploaded.
         """
         return self.upload(dataset_id, file_path)
-
-    def _upload_put_url_headers(self):
-        """
-        Returns headers necessary for requests to presigned put urls
-        :return: A dictionary representing the headers required for requests
-                to presigned URLs for uploading files
-        """
-        headers = {
-            "x-amz-server-side-encryption": "AES256",
-            "x-amz-acl": "private"
-        }
-        return headers
 
     def _data_analysis(self, model_name):
         """

--- a/citrination_client/client.py
+++ b/citrination_client/client.py
@@ -269,7 +269,7 @@ class CitrinationClient(object):
                 j = json.loads(r.content.decode('utf-8'))
                 s3url = self._get_s3_presigned_url(j)
                 with open(source_path, 'rb') as f:
-                    r = requests.put(s3url, data=f)
+                    r = requests.put(s3url, data=f, headers=self._upload_put_url_headers())
                     if r.status_code == 200:
                         url_data = {'s3object': j['url']['path'], 's3bucket': j['bucket']}
                         requests.post(self._get_update_file_upload_url(j['file_id']),
@@ -303,6 +303,18 @@ class CitrinationClient(object):
         :return: Response object or return code if the file was not uploaded.
         """
         return self.upload(dataset_id, file_path)
+
+    def _upload_put_url_headers(self):
+        """
+        Returns headers necessary for requests to presigned put urls
+        :return: A dictionary representing the headers required for requests
+                to presigned URLs for uploading files
+        """
+        headers = {
+            "x-amz-server-side-encryption": "AES256",
+            "x-amz-acl": "private"
+        }
+        return headers
 
     def _data_analysis(self, model_name):
         """


### PR DESCRIPTION
  By requiring the use of server side encryption in the buckets used in the
  back end, we require that the `x-amz-acl` and `x-amz-server-side-encryption`
  headers be present on the request to the presigned url that uploads files.

  This commit adds the necessary headers.