### PR TITLE
Relaxing the prediction tolerances

### DIFF
--- a/citrination_client/tests/test_client.py
+++ b/citrination_client/tests/test_client.py
@@ -71,12 +71,12 @@ class TestClient():
         assert egap    in prediction, "E_gap prediction missing (check ML logic)"
         assert voltage in prediction, "V_OC prediction missing (check ML logic)"
  
-        assert _almost_equal(prediction['Mass'][0], 250,  50.0), "Mass mean prediction beyond tolerance (check ML logic)"
-        assert _almost_equal(prediction['Mass'][1], 30.0, 30.0), "Mass sigma prediction beyond tolerance (check ML logic)"
-        assert _almost_equal(prediction[egap][0], 2.6,  0.6), "E_gap mean prediction beyond tolerance (check ML logic)"
-        assert _almost_equal(prediction[egap][1], 0.50, 0.45), "E_gap sigma prediction beyond tolerance (check ML logic)"
-        assert _almost_equal(prediction[voltage][0], 1.0, 0.8), "V_OC mean prediction beyond tolerance (check ML logic)"
-        assert _almost_equal(prediction[voltage][1], 0.8, 0.8), "V_OC sigma prediction beyond tolerance (check ML logic)"
+        assert _almost_equal(prediction['Mass'][0], 250,  60.0), "Mass mean prediction beyond tolerance (check ML logic)"
+        assert _almost_equal(prediction['Mass'][1], 30.0, 40.0), "Mass sigma prediction beyond tolerance (check ML logic)"
+        assert _almost_equal(prediction[egap][0], 2.6,  0.7), "E_gap mean prediction beyond tolerance (check ML logic)"
+        assert _almost_equal(prediction[egap][1], 0.50, 0.55), "E_gap sigma prediction beyond tolerance (check ML logic)"
+        assert _almost_equal(prediction[voltage][0], 1.0, 0.9), "V_OC mean prediction beyond tolerance (check ML logic)"
+        assert _almost_equal(prediction[voltage][1], 0.8, 0.9), "V_OC sigma prediction beyond tolerance (check ML logic)"
 
     def test_predict(self):
         """


### PR DESCRIPTION
The from_distribution predictions are noisier (and more robust), so
let's relax the tolerances.  Plus, we test for correctness elsewhere,
 so doing such fine grained tests isn't particularly motivated here.