### PR TITLE
Use a valid dataset in tests

### DIFF
--- a/citrination_client/search/dataset/tests/test_dataset_query.py
+++ b/citrination_client/search/dataset/tests/test_dataset_query.py
@@ -40,7 +40,7 @@ class TestDatasetQuery(unittest.TestCase):
             size=0,
             query=DataQuery(
                 dataset=DatasetQuery(
-                    id=Filter(equal='151278')))))
+                    id=Filter(equal='150675')))))
         assert 1 == response.total_num_hits
 
     def test_search_limit_enforced_dataset_search(self):

--- a/citrination_client/search/pif/tests/test_pif_query.py
+++ b/citrination_client/search/pif/tests/test_pif_query.py
@@ -90,13 +90,13 @@ class TestPifQuery():
             size=0,
             query=DataQuery(
                 dataset=DatasetQuery(
-                    id=Filter(equal='151278')
+                    id=Filter(equal='150675')
                 ),
                 system=PifSystemQuery(
                     chemical_formula=ChemicalFieldQuery(
                         filter=ChemicalFilter(
-                            equal='C22H15NSSi'))))))
-        assert 5 == response.total_num_hits
+                            equal='AlCu'))))))
+        assert 4 == response.total_num_hits
 
     @pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
                         reason="Test only supported on public")
@@ -108,10 +108,10 @@ class TestPifQuery():
             size=0,
             query=DataQuery(
                 dataset=DatasetQuery(
-                    id=Filter(equal='151278')
+                    id=Filter(equal='150675')
                 ),
-                simple='C22H15NSSi')))
-        assert 5 == response.total_num_hits
+                simple='AlCu')))
+        assert 4 == response.total_num_hits
 
     @pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
                         reason="Test only supported on public")
@@ -124,14 +124,14 @@ class TestPifQuery():
             size=1,
             query=DataQuery(
                 dataset=DatasetQuery(
-                    id=Filter(equal='151278')
+                    id=Filter(equal='150675')
                 ),
                 system=PifSystemQuery(
                     chemical_formula=ChemicalFieldQuery(
                         extract_as='Chemical formula',
                         filter=ChemicalFilter(
-                            equal='C22H15NSSi'))))))
-        assert response.hits[0].extracted['Chemical formula'] == '$\\rm$C$_{22}$$\\rm$H$_{15}$$\\rm$N$\\rm$S$\\rm$Si'
+                            equal='AlCu'))))))
+        assert response.hits[0].extracted['Chemical formula'] == 'AlCu'
         assert response.hits[0].extracted_path['Chemical formula'] == '/chemicalFormula'
 
     def test_updated_at(self):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='4.0.1',
+      version='4.1.0',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(exclude=('docs')),


### PR DESCRIPTION
There are 4 test failures in the release 4.1.0.  This commit uses dataset 150675 and Chemical formula: AlCu.  With this commit, all the tests pass.