### PR TITLE
Hotfix - Infinity Serialization

### DIFF
--- a/citrination_client/models/design/constraints/real_range.py
+++ b/citrination_client/models/design/constraints/real_range.py
@@ -1,5 +1,6 @@
 from citrination_client.models.design.constraints.base import BaseConstraint
 from citrination_client.base.errors import CitrinationClientError
+import citrination_client.util.maths as maths
 
 class RealRangeConstraint(BaseConstraint):
     """
@@ -34,7 +35,10 @@ class RealRangeConstraint(BaseConstraint):
         self._name = name
 
     def options(self):
+        minimum = maths.convert_infinity_to_string(self._min)
+        maximum = maths.convert_infinity_to_string(self._max)
+
         return {
-            "min": self._min,
-            "max": self._max
+            "min": minimum,
+            "max": maximum
         }

--- a/citrination_client/models/tests/test_models_client.py
+++ b/citrination_client/models/tests/test_models_client.py
@@ -141,6 +141,18 @@ def test_experimental_design():
     assert len(results.best_materials) > 0
 
 @pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com", reason="Design tests only supported on qa")
+def test_experimental_design_infinity_constraint():
+    """
+    Tests that a design run can be triggered with an Infinity Constraint
+    """
+    view_id = "138"
+    run = _trigger_run(client, view_id, target=None, constraints=[RealRangeConstraint(name="Property Band gap", minimum=0, maximum=float("inf"))])
+
+    assert_run_accepted(view_id, run, client)
+    kill_and_assert_killed(view_id, run, client)
+
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com", reason="Design tests only supported on qa")
 def test_design_run_effort_limit():
     """
     Tests that a design run cannot be submitted with an effort

--- a/citrination_client/util/maths.py
+++ b/citrination_client/util/maths.py
@@ -1,0 +1,9 @@
+import math
+
+def convert_infinity_to_string(number):
+    if math.isinf(number):
+        if number < 0:
+            return "-Infinity"
+        if number > 0:
+            return "Infinity"
+    return number

--- a/citrination_client/util/tests/test_maths.py
+++ b/citrination_client/util/tests/test_maths.py
@@ -1,0 +1,13 @@
+from citrination_client.util.maths import *
+
+def test_negative_infinity_becomes_string():
+    infinity = float("-inf")
+    assert "-Infinity" == convert_infinity_to_string(infinity)
+
+def test_positive_infinity_becomes_string():
+    infinity = float("+inf")
+    assert "Infinity" == convert_infinity_to_string(infinity)
+
+def test_random_number_doesnt_change():
+    number = 1
+    assert number == convert_infinity_to_string(number)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='4.1.1',
+      version='4.1.2',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(exclude=('docs')),


### PR DESCRIPTION
Citrination requires that Infinity values be serialized
  as strings rather than constants.