### PR TITLE
Throw Appropriate Exception For 404s

### DIFF
--- a/citrination_client/base/response_handling.py
+++ b/citrination_client/base/response_handling.py
@@ -41,6 +41,7 @@ def raise_on_response(response):
     _check_response_for_feature_availability(response)
     _check_response_for_authorization(response)
     _check_response_for_timeout(response)
+    _check_response_for_missing_resource(response)
     _check_response_for_server_error(response)
     return response
 
@@ -55,6 +56,10 @@ def _check_response_for_feature_availability(response):
 def _check_response_for_timeout(response):
     if response.status_code == 524:
         raise RequestTimeoutException()
+
+def _check_response_for_missing_resource(response):
+    if response.status_code == 404:
+        raise ResourceNotFoundException()
 
 def _check_response_for_server_error(response):
     if response.status_code >= 500:

--- a/citrination_client/base/tests/test_response_handling.py
+++ b/citrination_client/base/tests/test_response_handling.py
@@ -14,6 +14,9 @@ response_exceptions = [{
     },{
         "code": requests.codes.unauthorized,
         "exception_class": UnauthorizedAccessException
+    },{
+        "code": requests.codes.not_found,
+        "exception_class": ResourceNotFoundException
     }]
 
 def test_raises_exceptions_correctly():

--- a/citrination_client/data/tests/test_data_client.py
+++ b/citrination_client/data/tests/test_data_client.py
@@ -48,7 +48,7 @@ def test_upload_pif():
         try:
             pif = client.get_pif(dataset_id, uid)
             break
-        except CitrinationServerErrorException:
+        except ResourceNotFoundException:
             if tries < 10:
                 tries += 1
                 time.sleep(1)


### PR DESCRIPTION
Throws ResourceNotFound as opposed to CitrinationServerError