### PR TITLE
Add proxies param to the CitrinationClient (base)

### DIFF
--- a/citrination_client/base/base_client.py
+++ b/citrination_client/base/base_client.py
@@ -15,7 +15,7 @@ class BaseClient(object):
     Base class that holds the universal constructor, utilities, etc
     """
 
-    def __init__(self, api_key, webserver_host, api_members=[], suppress_warnings=False):
+    def __init__(self, api_key, webserver_host, api_members=[], suppress_warnings=False, proxies = None):
         """
         Constructor.
 
@@ -28,9 +28,17 @@ class BaseClient(object):
         :param suppress_warnings: A flag indicating whether or not warning
             messages to stdout should be printed
         :type suppress_warnings: bool
+        :param proxies: proxies to use when making HTTP requests. E.g.,
+                proxies = {
+                  'http': 'http://10.10.1.10:3128',
+                  'https': 'http://10.10.1.10:1080',
+                }
+        :type proxies: dict(string, string)
         """
         if api_key == None or len(api_key) == 0:
             raise CitrinationClientError("API key must be present to instantiate the client")
+
+        self.proxies = proxies
 
         self.headers = {
             'X-API-Key': quote(api_key),
@@ -76,7 +84,9 @@ class BaseClient(object):
         :return:
         """
         headers = self._get_headers(headers)
-        response_lambda = (lambda: requests.get(self._get_qualified_route(route), headers=headers, verify=False))
+        response_lambda = (
+            lambda: requests.get(self._get_qualified_route(route), headers=headers, verify=False, proxies=self.proxies)
+        )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
         return self._handle_response(response, failure_message)
 
@@ -91,7 +101,11 @@ class BaseClient(object):
         :return:
         """
         headers = self._get_headers(headers)
-        response_lambda = (lambda: requests.post(self._get_qualified_route(route), headers=headers, data=data, verify=False))
+        response_lambda = (
+            lambda: requests.post(
+                self._get_qualified_route(route), headers=headers, data=data, verify=False, proxies=self.proxies
+            )
+        )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
         return self._handle_response(response, failure_message)
 
@@ -106,7 +120,11 @@ class BaseClient(object):
         :return:
         """
         headers = self._get_headers(headers)
-        response_lambda = (lambda: requests.put(self._get_qualified_route(route), headers=headers, data=data, verify=False))
+        response_lambda = (
+            lambda: requests.put(
+                self._get_qualified_route(route), headers=headers, data=data, verify=False, proxies=self.proxies
+            )
+        )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
         return self._handle_response(response, failure_message)
 
@@ -117,7 +135,9 @@ class BaseClient(object):
         :return:
         """
         headers = self._get_headers(headers)
-        response_lambda = (lambda: requests.delete(self._get_qualified_route(route), headers=headers, verify=False))
+        response_lambda = (lambda: requests.delete(
+            self._get_qualified_route(route), headers=headers, verify=False, proxies=self.proxies)
+                           )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
         return self._handle_response(response, failure_message)
 

--- a/citrination_client/data/client.py
+++ b/citrination_client/data/client.py
@@ -14,7 +14,7 @@ class DataClient(BaseClient):
     Client encapsulating data management behavior.
     """
 
-    def __init__(self, api_key, host="https://citrination.com", suppress_warnings=False):
+    def __init__(self, api_key, host="https://citrination.com", suppress_warnings=False, proxies=None):
         """
         Constructor.
 
@@ -36,7 +36,7 @@ class DataClient(BaseClient):
             "create_dataset",
             "create_dataset_version"
         ]
-        super(DataClient, self).__init__(api_key, host, members, suppress_warnings=suppress_warnings)
+        super(DataClient, self).__init__(api_key, host, members, suppress_warnings, proxies)
 
     def upload(self, dataset_id, source_path, dest_path=None):
         """

--- a/citrination_client/data/tests/test_data_client.py
+++ b/citrination_client/data/tests/test_data_client.py
@@ -112,6 +112,7 @@ def test_dataset_update():
     """
     dataset_name = random_dataset_name()
     dataset_id = client.create_dataset(name=dataset_name).id
+    time.sleep(10)
     new_name = random_dataset_name()
     new_description = random_string()
     dataset = client.update_dataset(dataset_id, name=new_name, description=new_description)

--- a/citrination_client/models/client.py
+++ b/citrination_client/models/client.py
@@ -15,12 +15,12 @@ class ModelsClient(BaseClient):
     A client that encapsulates interactions with models on Citrination.
     """
 
-    def __init__(self, api_key, webserver_host="https://citrination.com", suppress_warnings=False):
+    def __init__(self, api_key, webserver_host="https://citrination.com", suppress_warnings=False, proxies=None):
         members = [
             "tsne",
             "predict"
         ]
-        super(ModelsClient, self).__init__(api_key, webserver_host, members, suppress_warnings=suppress_warnings)
+        super(ModelsClient, self).__init__(api_key, webserver_host, members, suppress_warnings, proxies)
 
     def tsne(self, data_view_id):
         """

--- a/citrination_client/search/client.py
+++ b/citrination_client/search/client.py
@@ -18,13 +18,13 @@ MAX_QUERY_DEPTH = 50000
 
 
 class SearchClient(BaseClient):
-    def __init__(self, api_key, webserver_host="https://citrination.com", suppress_warnings=False):
+    def __init__(self, api_key, webserver_host="https://citrination.com", suppress_warnings=False, proxies=None):
         members = [
             "pif_search",
             "pif_multi_search",
             "dataset_search"
         ]
-        super(SearchClient, self).__init__(api_key, webserver_host, members, suppress_warnings=suppress_warnings)
+        super(SearchClient, self).__init__(api_key, webserver_host, members, suppress_warnings, proxies)
 
     def _handle_response(self, response, failure_message=DEFAULT_FAILURE_MESSAGE):
         if response.status_code == 204:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='4.4.2',
+      version='4.5.0',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(exclude=('docs')),


### PR DESCRIPTION
This PR adds an optional `proxies` parameter to the CitrinationClient. The proxies dict will be passed along to the requests module for all HTTP requests.