### PR TITLE
added link to html version of tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 This package is an implementation of the Citrination API.
 
+You can learn about the functionalities of the python-citrination-client through the following [tutorials](http://citrineinformatics.github.io/python-citrination-client/).
+
 ## Installation
 
 ### Requirements


### PR DESCRIPTION
We have a nice set of tutorials for citrination-client, but unfortunately a link to the html version (compiling the .rst files from docs and the code snippets) does not exist from within the repo where people would look for it.