### PR TITLE
added jupyter tutorials to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 This package is an implementation of the Citrination API.
 
-You can learn about the functionalities of the python-citrination-client through the following [tutorials](http://citrineinformatics.github.io/python-citrination-client/).
+You can learn about the functionalities of the python-citrination-client through the following [documentation](http://citrineinformatics.github.io/python-citrination-client/).
+
+Tutorials and examples presented using Jupyter notebooks can be found in [community-tools](https://github.com/CitrineInformatics/community-tools) and [learn-citrination](https://github.com/CitrineInformatics/learn-citrination).
 
 ## Installation
 


### PR DESCRIPTION
Just added more links to connect all of our work. Pretty sure I branched from develop so I'm not sure what's failing...feel free to add this content however is easiest. It's only 1 extra line in the README.