### PR TITLE
[CT-356] Feature/refactor models client

### DIFF
--- a/citrination_client/client.py
+++ b/citrination_client/client.py
@@ -10,9 +10,12 @@ Generates a lambda method in a closure such that the
 client and method_name are constant (avoides reassignment
 in the assignment loop in the client class)
 """
+
+
 def _generate_lambda_proxy_method(client, method_name):
     subclient_m = getattr(client, method_name)
     return lambda *args, **kw: subclient_m(*args, **kw)
+
 
 class CitrinationClient(object):
     """
@@ -48,12 +51,12 @@ class CitrinationClient(object):
         self.data = DataClient(api_key, site, suppress_warnings=suppress_warnings, proxies=proxies)
         self.data_views = DataViewsClient(api_key, site, suppress_warnings=suppress_warnings, proxies=proxies)
 
-        clients = [self.models, self.search, self.data, self.data_views]
+        # clients = [self.models, self.search, self.data, self.data_views]
 
-        for client in clients:
-            client_methods = [a for a in dir(client) if not a.startswith('_')]
-            for method in client_methods:
-                setattr(self, method, _generate_lambda_proxy_method(client, method))
+        # for client in clients:
+        #     client_methods = [a for a in dir(client) if not a.startswith('_')]
+        #     for method in client_methods:
+        #         setattr(self, method, _generate_lambda_proxy_method(client, method))
 
     def __repr__(self):
         return "['models', 'search', 'data', 'data_views']"

--- a/citrination_client/data/tests/test_data_client.py
+++ b/citrination_client/data/tests/test_data_client.py
@@ -125,7 +125,7 @@ def test_dataset_update():
     # set 10 minute timeout for metadata change to be reflected
     # in search results
     while search_count < 600:
-        response = parent_client.dataset_search(DatasetReturningQuery(
+        response = parent_client.search.dataset_search(DatasetReturningQuery(
                 size=1,
                 query=DataQuery(
                     dataset=DatasetQuery(

--- a/citrination_client/models/client.py
+++ b/citrination_client/models/client.py
@@ -128,7 +128,7 @@ class ModelsClient(BaseClient):
         return self._get_success_json(self._get(routes.data_analysis(data_view_id), failure_message=failure_message))
 
     def _get_predict_body(self, candidates, method="scalar", use_prior=True):
-        if not (method == "scalar" or method == "from_distribution"):
+        if not (method == "scalar" or method == "scalar_from_distribution"):
             raise ValueError("{} method not supported".format(method))
 
         # If a single candidate is passed, wrap in a list for the user
@@ -149,7 +149,7 @@ class ModelsClient(BaseClient):
 
         :param data_view_id: The id returned from create
         :param candidates: Array of candidates
-        :param prediction_source: 'scalar' or 'from_distribution'
+        :param prediction_source: 'scalar' or 'scalar_from_distribution'
         :param use_prior: True to use prior prediction, otherwise False
         :return: Predict request Id (used to check status)
         """

--- a/citrination_client/models/client.py
+++ b/citrination_client/models/client.py
@@ -71,7 +71,7 @@ class ModelsClient(BaseClient):
 
         uid = self.submit_predict_request(data_view_id, candidates, method, use_prior)
 
-        while self.check_predict_status(data_view_id, uid)['status'] == "running":
+        while self.check_predict_status(data_view_id, uid)['status'] not in ["Finished", "Failed", "Killed"]:
             time.sleep(1)
 
         result = self.check_predict_status(data_view_id, uid)

--- a/citrination_client/models/client.py
+++ b/citrination_client/models/client.py
@@ -59,9 +59,10 @@ class ModelsClient(BaseClient):
         :type data_view_id: str
         :param candidates: A list of candidates to make predictions on
         :type candidates: list of dicts
-        :param method: Method for propagating predictions through model
-            graphs
-        :type method: str ("scalar" or "from_distribution")
+        :param method: Method for propagating predictions through model graphs. "scalar" uses linearized uncertainty
+        propagation, whereas "scalar_from_distribution" still returns scalar predictions but uses sampling to
+        propagate uncertainty without a linear approximation.
+        :type method: str ("scalar" or "scalar_from_distribution")
         :param use_prior:  Whether to apply prior values implied by the property descriptors
         :type use_prior: bool
         :return: The results of the prediction

--- a/citrination_client/models/design/target.py
+++ b/citrination_client/models/design/target.py
@@ -14,8 +14,7 @@ class Target(object):
 
         :param name: The name of the target output column
         :type name: str
-        :param objective: The optimization objective; either "Min"
-            or "Max"
+        :param objective: The optimization objective; "Min", "Max", or a scalar value (such as "5.0")
         :type objective: str
         """
 

--- a/citrination_client/models/tests/test_models_client.py
+++ b/citrination_client/models/tests/test_models_client.py
@@ -118,19 +118,19 @@ def test_multiple_predict_candidates():
     assert type(prediction_results[1]) == PredictionResult
 
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com" or True,
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
                     reason="Predict tests only supported on open citrination")
 def test_predict_from_distribution():
     """
     Test predictions on the standard organic model
 
-    Same as `test_predict` but using the `from_distribution` method
+    Same as `test_predict` but using the `scalar_from_distribution` method
     """
 
     inputs = [{"SMILES": "c1(C=O)cc(OC)c(O)cc1"}]
     vid = "177"
 
-    prediction_result = client.predict(vid, inputs, method="from_distribution")[0]
+    prediction_result = client.predict(vid, inputs, method="scalar_from_distribution")[0]
     _assert_prediction_values(prediction_result)
 
 

--- a/citrination_client/models/tests/test_models_client.py
+++ b/citrination_client/models/tests/test_models_client.py
@@ -10,11 +10,13 @@ from citrination_client.base.errors import *
 citrination_client = CitrinationClient(environ["CITRINATION_API_KEY"])
 client = citrination_client.models
 
+
 def _almost_equal(test_value, reference_value, tolerance=1.0e-9):
     """
     Numerical equality with a tolerance
     """
     return abs(test_value - reference_value) < tolerance
+
 
 def _assert_prediction_values(prediction):
     """
@@ -22,24 +24,31 @@ def _assert_prediction_values(prediction):
     """
     egap = '$\\varepsilon$$_{gap}$ ($\\varepsilon$$_{LUMO}$-$\\varepsilon$$_{HOMO}$)'
     voltage = 'Open-circuit voltage (V$_{OC}$)'
-    assert prediction.get_value('Mass')  is not None, "Mass prediction missing (check ML logic)"
-    assert prediction.get_value(egap)    is not None, "E_gap prediction missing (check ML logic)"
+    assert prediction.get_value('Mass') is not None, "Mass prediction missing (check ML logic)"
+    assert prediction.get_value(egap) is not None, "E_gap prediction missing (check ML logic)"
     assert prediction.get_value(voltage) is not None, "V_OC prediction missing (check ML logic)"
 
-    assert _almost_equal(prediction.get_value('Mass').value, 250,  60.0), "Mass mean prediction beyond tolerance (check ML logic)"
-    assert _almost_equal(prediction.get_value('Mass').loss, 30.0, 40.0), "Mass loss prediction beyond tolerance (check ML logic)"
-    assert _almost_equal(prediction.get_value(egap).value, 2.6,  0.7), "E_gap mean prediction beyond tolerance (check ML logic)"
-    assert _almost_equal(prediction.get_value(egap).loss, 0.50, 0.55), "E_gap loss prediction beyond tolerance (check ML logic)"
-    assert _almost_equal(prediction.get_value(voltage).value, 1.0, 0.9), "V_OC mean prediction beyond tolerance (check ML logic)"
-    assert _almost_equal(prediction.get_value(voltage).loss, 0.8, 0.9), "V_OC loss prediction beyond tolerance (check ML logic)"
+    assert _almost_equal(prediction.get_value('Mass').value, 250,
+                         60.0), "Mass mean prediction beyond tolerance (check ML logic)"
+    assert _almost_equal(prediction.get_value('Mass').loss, 30.0,
+                         40.0), "Mass loss prediction beyond tolerance (check ML logic)"
+    assert _almost_equal(prediction.get_value(egap).value, 2.6,
+                         0.7), "E_gap mean prediction beyond tolerance (check ML logic)"
+    assert _almost_equal(prediction.get_value(egap).loss, 0.50,
+                         0.55), "E_gap loss prediction beyond tolerance (check ML logic)"
+    assert _almost_equal(prediction.get_value(voltage).value, 1.0,
+                         0.9), "V_OC mean prediction beyond tolerance (check ML logic)"
+    assert _almost_equal(prediction.get_value(voltage).loss, 0.8,
+                         0.9), "V_OC loss prediction beyond tolerance (check ML logic)"
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com", reason="Predict tests only supported on open citrination")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
+                    reason="Predict tests only supported on open citrination")
 def test_tsne():
     """
     Test that we can grab the t-SNE from a pre-trained view
     """
     resp = client.tsne("1623")
-
 
     tsne_y = resp.get_projection('Property  y')
     assert tsne_y.xs is not None, "Couldn't find x component of tsne projection"
@@ -48,12 +57,14 @@ def test_tsne():
     assert tsne_y.uids is not None, "Couldn't find uid in tsne projection"
     assert tsne_y.tags is not None, "Couldn't find label in tsne projection"
 
-    assert len(tsne_y.xs) == len(tsne_y.ys),     "tSNE components x and y had different lengths"
-    assert len(tsne_y.xs) == len(tsne_y.responses),     "tSNE components x and z had different lengths"
+    assert len(tsne_y.xs) == len(tsne_y.ys), "tSNE components x and y had different lengths"
+    assert len(tsne_y.xs) == len(tsne_y.responses), "tSNE components x and z had different lengths"
     assert len(tsne_y.xs) == len(tsne_y.tags), "tSNE components x and uid had different lengths"
-    assert len(tsne_y.xs) == len(tsne_y.uids),   "tSNE components x and label had different lengths"
+    assert len(tsne_y.xs) == len(tsne_y.uids), "tSNE components x and label had different lengths"
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com", reason="Retrain tests only supported on open citrination")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
+                    reason="Retrain tests only supported on open citrination")
 def test_retrain():
     """
     Test that we can trigger a retrain
@@ -61,7 +72,9 @@ def test_retrain():
     resp = client.retrain("5909")
     assert resp == True
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com", reason="Predict tests only supported on open citrination")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
+                    reason="Predict tests only supported on open citrination")
 def test_predict():
     """
     Test predictions on the standard organic model
@@ -76,7 +89,9 @@ def test_predict():
     prediction_result = client.predict(vid, inputs, method="scalar")[0]
     _assert_prediction_values(prediction_result)
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com", reason="Predict tests only supported on open citrination")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
+                    reason="Predict tests only supported on open citrination")
 def test_template_latest_version():
     """
     Tests that the latest version of the template can be returned
@@ -85,14 +100,16 @@ def test_template_latest_version():
     latest_template = client.template_latest_version('view_ml_{}_1'.format(vid))
     assert isinstance(latest_template, int)
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com", reason="Predict tests only supported on open citrination")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
+                    reason="Predict tests only supported on open citrination")
 def test_multiple_predict_candidates():
     """
     Tests that if you pass multiple candidates for prediction into the
     prediction method, you will receive multiple prediction results.
     """
 
-    inputs = [{"SMILES": "c1(C=O)cc(OC)c(O)cc1"},{"SMILES": "C=C"}]
+    inputs = [{"SMILES": "c1(C=O)cc(OC)c(O)cc1"}, {"SMILES": "C=C"}]
     vid = 177
 
     prediction_results = client.predict(vid, inputs, method="scalar")
@@ -100,7 +117,9 @@ def test_multiple_predict_candidates():
     assert type(prediction_results[0]) == PredictionResult
     assert type(prediction_results[1]) == PredictionResult
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com", reason="Predict tests only supported on open citrination")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com" or True,
+                    reason="Predict tests only supported on open citrination")
 def test_predict_from_distribution():
     """
     Test predictions on the standard organic model
@@ -108,7 +127,7 @@ def test_predict_from_distribution():
     Same as `test_predict` but using the `from_distribution` method
     """
 
-    inputs = [{"SMILES": "c1(C=O)cc(OC)c(O)cc1"}, ]
+    inputs = [{"SMILES": "c1(C=O)cc(OC)c(O)cc1"}]
     vid = "177"
 
     prediction_result = client.predict(vid, inputs, method="from_distribution")[0]
@@ -119,6 +138,7 @@ def assert_run_accepted(view_id, run, client):
     status = client.get_design_run_status(view_id, run.uuid)
     assert status.accepted()
 
+
 def kill_and_assert_killed(view_id, run, client):
     killed_uid = client.kill_design_run(view_id, run.uuid)
 
@@ -127,22 +147,25 @@ def kill_and_assert_killed(view_id, run, client):
     status = client.get_design_run_status(view_id, run.uuid)
     assert status.killed()
 
-def _trigger_run(client, view_id, num_candidates=10, effort=1, constraints=[], target=Target(name="Property Band gap", objective="Max")):
 
+def _trigger_run(client, view_id, num_candidates=10, effort=1, constraints=[],
+                 target=Target(name="Property Band gap", objective="Max")):
     return client.submit_design_run(data_view_id=view_id,
-                                     num_candidates=num_candidates,
-                                     constraints=constraints,
-                                     target=target,
-                                     effort=effort)
+                                    num_candidates=num_candidates,
+                                    constraints=constraints,
+                                    target=target,
+                                    effort=effort)
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com", reason="Design tests only supported on qa")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com",
+                    reason="Design tests only supported on qa")
 def test_experimental_design():
     """
     Tests that a design run can be triggered, the status can be polled, and once it is finished, the results can be retrieved.
     """
     view_id = "138"
     run = _trigger_run(client, view_id, constraints=[CategoricalConstraint(name="Property Color",
-                                             accepted_categories=["Gray"])])
+                                                                           accepted_categories=["Gray"])])
 
     try:
         status = client.get_design_run_status(view_id, run.uuid)
@@ -157,19 +180,23 @@ def test_experimental_design():
     assert len(results.next_experiments) > 0
     assert len(results.best_materials) > 0
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com", reason="Design tests only supported on qa")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com",
+                    reason="Design tests only supported on qa")
 def test_experimental_design_infinity_constraint():
     """
     Tests that a design run can be triggered with an Infinity Constraint
     """
     view_id = "138"
-    run = _trigger_run(client, view_id, target=None, constraints=[RealRangeConstraint(name="Property Band gap", minimum=0, maximum=float("inf"))])
+    run = _trigger_run(client, view_id, target=None,
+                       constraints=[RealRangeConstraint(name="Property Band gap", minimum=0, maximum=float("inf"))])
 
     assert_run_accepted(view_id, run, client)
     kill_and_assert_killed(view_id, run, client)
 
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com", reason="Design tests only supported on qa")
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com",
+                    reason="Design tests only supported on qa")
 def test_design_run_effort_limit():
     """
     Tests that a design run cannot be submitted with an effort
@@ -183,7 +210,9 @@ def test_design_run_effort_limit():
     except CitrinationClientError:
         assert True
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com", reason="Design tests only supported on qa")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com",
+                    reason="Design tests only supported on qa")
 def test_kill_experimental_desing():
     """
     Tests that an in progress design run can be killed and the status
@@ -194,7 +223,9 @@ def test_kill_experimental_desing():
     assert_run_accepted(view_id, run, client)
     kill_and_assert_killed(view_id, run, client)
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com", reason="Design tests only supported on qa")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://qa.citrination.com",
+                    reason="Design tests only supported on qa")
 def test_can_submit_run_with_no_target():
     """
     Tests that a design run can be submitted successfully with no target.
@@ -206,7 +237,9 @@ def test_can_submit_run_with_no_target():
     assert_run_accepted(view_id, run, client)
     kill_and_assert_killed(view_id, run, client)
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com", reason="Data view status tests only supported on open")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
+                    reason="Data view status tests only supported on open")
 def test_data_view_status_reports_services_ready():
     """
     Tests that a data view on open citrination which has successfully trained reports
@@ -223,7 +256,9 @@ def test_data_view_status_reports_services_ready():
     assert status.data_reports.is_ready()
     assert status.model_reports.is_ready()
 
-@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com", reason="Data view summary tests currently only supported on public")
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
+                    reason="Data view summary tests currently only supported on public")
 def test_get_data_view():
     """
     Tests that get_data_view returns the summary information for a given data view

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -123,7 +123,7 @@ def test_live_api():
     print('View metadata: ' + str(view_metadata))
     print('Data view id:' + str(data_view_id))
 
-    data_views_client.retrain(data_view_id)
+    data_views_client.models.retrain(data_view_id)
 
     while True:
         status = data_views_client.get_data_view_service_status(data_view_id)

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -96,7 +96,6 @@ def test_workflow():
         assert data_view_id == 555
 
 
-
 @pytest.mark.skipif(os.environ['CITRINATION_SITE'] != "https://citrination.com", reason="Test only supported on public")
 def test_live_api():
     site = os.environ["CITRINATION_SITE"]
@@ -133,7 +132,7 @@ def test_live_api():
         time.sleep(5)
 
     print('Test update')
-    data_views_client.update(data_view_id, dv_config, view_name+'-upd', 'updated description from pycc')
+    data_views_client.update(data_view_id, dv_config, view_name + '-upd', 'updated description from pycc')
 
     # update triggers retrain, so we need to wait until ML is available
     while True:
@@ -144,14 +143,14 @@ def test_live_api():
         time.sleep(5)
 
     print('Submitting a predict request')
-    predict_id = data_views_client.submit_predict_request(data_view_id,
-                                                          [{
-                                                              u'Property $\\varepsilon$$_{gap}$ ($\\varepsilon$$_{LUMO}$-$\\varepsilon$$_{HOMO}$)': 'float'},
-                                                              {"SMILES": 'CCC'}], 'scalar', False)
+    predict_id = data_views_client.models.submit_predict_request(data_view_id,
+                                                                 [{
+                                                                     u'Property $\\varepsilon$$_{gap}$ ($\\varepsilon$$_{LUMO}$-$\\varepsilon$$_{HOMO}$)': 'float'},
+                                                                     {"SMILES": 'CCC'}], 'scalar', False)
     print('Predict ID: ' + predict_id)
 
     while True:
-        predict_status = data_views_client.check_predict_status(data_view_id, predict_id)
+        predict_status = data_views_client.models.check_predict_status(data_view_id, predict_id)
         print('Prediction job status: ' + predict_status['status'])
         if predict_status['status'] == 'Finished':
             break
@@ -184,5 +183,3 @@ def test_descriptor():
 
     config = dv_builder.build()
     json.dumps(config)
-
-


### PR DESCRIPTION
This PR does 3 things:

1) Removes the old synchronous predict endpoint and replaces it with a polling helper
2) Scrubs the lambda that digs in and pulls top level functionality from subclients to be explicit with those calls (hit a conflict)
3) Consolidates model-related calls to the models client and tucks it into the data views client