### PR TITLE
Missed removing Infinity from valid descriptor bounds

### DIFF
--- a/citrination_client/models/client.py
+++ b/citrination_client/models/client.py
@@ -10,14 +10,12 @@ from citrination_client.models.data_view import DataView
 from citrination_client.models.columns.column_factory import ColumnFactory
 
 import requests
-import warnings
 import time
 
 
 class ModelsClient(BaseClient):
     """
-    A client that encapsulates interactions with models on Citrination. Note: As of version 4.9.0, this is deprecated
-    in favor of the DataViewsClient.
+    A client that encapsulates interactions with models on Citrination.
     """
 
     def __init__(self, api_key, webserver_host="https://citrination.com", suppress_warnings=False, proxies=None):
@@ -191,7 +189,7 @@ class ModelsClient(BaseClient):
 
     def submit_design_run(self, data_view_id, num_candidates, effort, target=None, constraints=[], sampler="Default"):
         """
-        Submits a new experimental design run. Note: As of version 4.9.0, this is deprecated.
+        Submits a new experimental design run.
 
         :param data_view_id: The ID number of the data view to which the
             run belongs, as a string
@@ -210,9 +208,6 @@ class ModelsClient(BaseClient):
         :return: A :class:`DesignRun` instance containing the UID of the
             new run
         """
-        warnings.warn("The ModelsClient.submit_design_run method (and associated status check) is being deprecated "
-                      "in favor of those defined in DataViewsClient")
-
         if effort > 30:
             raise CitrinationClientError("Parameter effort must be less than 30 to trigger a design run")
 

--- a/citrination_client/views/descriptors/real_descriptor.py
+++ b/citrination_client/views/descriptors/real_descriptor.py
@@ -2,7 +2,7 @@ from citrination_client.views.descriptors.descriptor import MaterialDescriptor
 
 
 class RealDescriptor(MaterialDescriptor):
-    def __init__(self, key, lower_bound="-Infinity", upper_bound="Infinity", units=""):
+    def __init__(self, key, lower_bound, upper_bound, units=""):
         self.options = dict(lower_bound=lower_bound, upper_bound=upper_bound, units=units)
         super(RealDescriptor, self).__init__(key, "Real")
 
@@ -11,11 +11,11 @@ class RealDescriptor(MaterialDescriptor):
         raw_upper = self.options["upper_bound"]
 
         try:
-            lower = float(str(raw_lower).replace("Infinity", "inf"))
-            upper = float(str(raw_upper).replace("Infinity", "inf"))
+            lower = float(str(raw_lower))
+            upper = float(str(raw_upper))
         except ValueError:
             raise ValueError(
-                "lower_bound and upper_bound must be floats (or Infinity/-Infinity) but got {} and {} respectively".format(
+                "lower_bound and upper_bound must be floats but got {} and {} respectively".format(
                     raw_lower, raw_upper)
             )
 

--- a/citrination_client/views/tests/test_data_view_builder.py
+++ b/citrination_client/views/tests/test_data_view_builder.py
@@ -18,5 +18,5 @@ def test_add_descriptor():
 
     # Make sure duplicates raise an error
     with pytest.raises(ValueError) as err:
-        builder.add_descriptor(RealDescriptor("band gap"), "input")
+        builder.add_descriptor(RealDescriptor("band gap", lower_bound=-1, upper_bound=1), "input")
 

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -85,7 +85,7 @@ def test_workflow():
 
         # Create ML configuration
         dv_builder = DataViewBuilder()
-        desc = RealDescriptor('Property Melting point', '-Infinity', '0')
+        desc = RealDescriptor('Property Melting point', '-10000000000', '0')
         dv_builder.add_descriptor(desc, 'Output')
         desc = OrganicDescriptor('Property SMILES')
         dv_builder.add_descriptor(desc, 'Input')
@@ -107,7 +107,7 @@ def test_live_api():
     dv_builder = DataViewBuilder()
     dv_builder.dataset_ids(['151278'])
     desc = RealDescriptor(u'Property $\\varepsilon$$_{gap}$ ($\\varepsilon$$_{LUMO}$-$\\varepsilon$$_{HOMO}$)',
-                          '-Infinity', '0')
+                          '-10000000', '0')
     dv_builder.add_descriptor(desc, 'output')
     desc = OrganicDescriptor('SMILES')
     dv_builder.add_descriptor(desc, 'input')
@@ -166,7 +166,7 @@ def test_descriptor():
     print('Testing descriptor')
     dv_builder = DataViewBuilder()
 
-    desc = RealDescriptor('Property 1')
+    desc = RealDescriptor('Property 1', lower_bound=-100000, upper_bound=1000000)
     dv_builder.add_descriptor(desc, 'input')
 
     desc = AlloyCompositionDescriptor('Property 2', 'Al')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='5.0.0',
+      version='5.0.1',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(exclude=('docs')),


### PR DESCRIPTION
This hotfix removes the (soon to be unsupported) default Infinity bounds from the RealDescriptor class.