### PR TITLE
force environment vars to not override proxies in requests

### DIFF
--- a/citrination_client/base/base_client.py
+++ b/citrination_client/base/base_client.py
@@ -85,7 +85,10 @@ class BaseClient(object):
         """
         headers = self._get_headers(headers)
         response_lambda = (
-            lambda: requests.get(self._get_qualified_route(route), headers=headers, verify=False, proxies=self.proxies)
+            lambda: requests.get(
+                self._get_qualified_route(route), headers=headers, 
+                verify=False, proxies=self.proxies, config={'trust_env': False}
+            )
         )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
         return self._handle_response(response, failure_message)
@@ -103,7 +106,8 @@ class BaseClient(object):
         headers = self._get_headers(headers)
         response_lambda = (
             lambda: requests.post(
-                self._get_qualified_route(route), headers=headers, data=data, verify=False, proxies=self.proxies
+                self._get_qualified_route(route), headers=headers, data=data, 
+                verify=False, proxies=self.proxies, config={'trust_env': False}
             )
         )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
@@ -122,7 +126,8 @@ class BaseClient(object):
         headers = self._get_headers(headers)
         response_lambda = (
             lambda: requests.put(
-                self._get_qualified_route(route), headers=headers, data=data, verify=False, proxies=self.proxies
+                self._get_qualified_route(route), headers=headers, data=data, 
+                verify=False, proxies=self.proxies, config={'trust_env': False}
             )
         )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
@@ -138,7 +143,8 @@ class BaseClient(object):
         headers = self._get_headers(headers)
         response_lambda = (
             lambda: requests.patch(
-                self._get_qualified_route(route), headers=headers, data=data, verify=False, proxies=self.proxies
+                self._get_qualified_route(route), headers=headers, data=data, 
+                verify=False, proxies=self.proxies, config={'trust_env': False}
             )
         )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
@@ -152,8 +158,10 @@ class BaseClient(object):
         """
         headers = self._get_headers(headers)
         response_lambda = (lambda: requests.delete(
-            self._get_qualified_route(route), headers=headers, verify=False, proxies=self.proxies)
-                           )
+                self._get_qualified_route(route), headers=headers, verify=False, 
+                proxies=self.proxies, config={'trust_env': False}
+            )
+        )
         response = check_for_rate_limiting(response_lambda(), response_lambda)
         return self._handle_response(response, failure_message)
 

--- a/citrination_client/data/client.py
+++ b/citrination_client/data/client.py
@@ -85,7 +85,10 @@ class DataClient(BaseClient):
                     data = "\0"
                 else:
                     data = f
-                r = requests.put(s3url, data=data, headers=j["required_headers"], proxies=self.proxies)
+                r = requests.put(
+                    s3url, data=data, headers=j["required_headers"], 
+                    proxies=self.proxies, config={'trust_env': False}
+                )
                 if r.status_code == 200:
                     data = {'s3object': j['url']['path'], 's3bucket': j['bucket']}
                     self._post_json(routes.update_file(j['file_id']), data=data)
@@ -235,7 +238,9 @@ class DataClient(BaseClient):
             if not os.path.isdir(os.path.dirname(local_path)):
                 os.makedirs(os.path.dirname(local_path))
 
-            r = requests.get(f.url, stream=True, proxies = self.proxies)
+            r = requests.get(
+                f.url, stream=True, proxies = self.proxies, config={'trust_env': False}
+            )
 
             with open(local_path, 'wb') as output_file:
                 shutil.copyfileobj(r.raw, output_file)


### PR DESCRIPTION
This forces all `requests` calls to use only the given proxies and not let local environment variables override the given proxies. This should fix some rare proxy-related errors.