### PR TITLE
Feature/async optional

### DIFF
--- a/citrination_client/base/base_client.py
+++ b/citrination_client/base/base_client.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import time
 
 from citrination_client.util.quote_finder import quote
 from citrination_client.base.response_handling import raise_on_response, check_general_success, check_for_rate_limiting, get_response_json
@@ -56,6 +57,18 @@ class BaseClient(object):
         raise_on_response(response)
         check_general_success(response, failure_message)
         return response
+
+    def _wait_for(self, activity_description, criterion, timeout, check_delay=5):
+        start = time.time()
+        while time.time() - start < timeout:
+            time.sleep(check_delay)
+            try:
+                if criterion():
+                    return
+            except Exception as e:
+                print("Error checking wait criterion: {}".format(e))
+
+        raise RuntimeError("Failed to `{}` in {} seconds".format(activity_description, timeout))
 
     def _get_success_json(self, response):
         return get_response_json(response)

--- a/citrination_client/base/base_client.py
+++ b/citrination_client/base/base_client.py
@@ -68,7 +68,7 @@ class BaseClient(object):
             except Exception as e:
                 print("Error checking wait criterion: {}".format(e))
 
-        raise RuntimeError("Failed to `{}` in {} seconds".format(activity_description, timeout))
+        raise RuntimeWarning("`{}` not yet complete after {} seconds, please check status manually".format(activity_description, timeout))
 
     def _get_success_json(self, response):
         return get_response_json(response)

--- a/citrination_client/data/client.py
+++ b/citrination_client/data/client.py
@@ -79,7 +79,7 @@ class DataClient(BaseClient):
             if not is_async:
                 self._wait_for(
                     "Dataset ingestion finished",
-                    lambda x: self.get_ingest_status(dataset_id) != "Finished",
+                    lambda x: self.get_ingest_status(dataset_id) == "Finished",
                     timeout)
             return upload_result
         elif os.path.isfile(source_path):
@@ -103,7 +103,7 @@ class DataClient(BaseClient):
                     if not is_async:
                         self._wait_for(
                             "Dataset ingestion finished",
-                            lambda x: self.get_ingest_status(dataset_id) != "Finished",
+                            lambda x: self.get_ingest_status(dataset_id) == "Finished",
                             timeout)
                     return upload_result
                 else:

--- a/citrination_client/data/client.py
+++ b/citrination_client/data/client.py
@@ -81,7 +81,7 @@ class DataClient(BaseClient):
             if not is_async:
                 self._wait_for(
                     "Dataset ingestion finished",
-                    lambda _: self.get_ingest_status(dataset_id) == "Finished",
+                    lambda: self.get_ingest_status(dataset_id) == "Finished",
                     timeout)
             return upload_result
         elif os.path.isfile(source_path):
@@ -105,7 +105,7 @@ class DataClient(BaseClient):
                     if not is_async:
                         self._wait_for(
                             "Dataset ingestion finished",
-                            lambda _: self.get_ingest_status(dataset_id) == "Finished",
+                            lambda: self.get_ingest_status(dataset_id) == "Finished",
                             timeout)
                     return upload_result
                 else:

--- a/citrination_client/data/client.py
+++ b/citrination_client/data/client.py
@@ -54,12 +54,14 @@ class DataClient(BaseClient):
         :return: The result of the upload process
         :rtype: :class:`UploadResult`
         """
+
         upload_result = UploadResult()
         source_path = str(source_path)
         if not dest_path:
             dest_path = source_path
         else:
             dest_path = str(dest_path)
+
         if os.path.isdir(source_path):
             for path, subdirs, files in os.walk(source_path):
                 relative_path = os.path.relpath(path, source_path)
@@ -79,7 +81,7 @@ class DataClient(BaseClient):
             if not is_async:
                 self._wait_for(
                     "Dataset ingestion finished",
-                    lambda x: self.get_ingest_status(dataset_id) == "Finished",
+                    lambda _: self.get_ingest_status(dataset_id) == "Finished",
                     timeout)
             return upload_result
         elif os.path.isfile(source_path):
@@ -103,7 +105,7 @@ class DataClient(BaseClient):
                     if not is_async:
                         self._wait_for(
                             "Dataset ingestion finished",
-                            lambda x: self.get_ingest_status(dataset_id) == "Finished",
+                            lambda _: self.get_ingest_status(dataset_id) == "Finished",
                             timeout)
                     return upload_result
                 else:

--- a/citrination_client/data/tests/test_data_client.py
+++ b/citrination_client/data/tests/test_data_client.py
@@ -61,6 +61,30 @@ def test_upload_pif():
     with open("tmp.json", "r") as fp:
         assert json.loads(fp.read())["uid"] == pif.uid
 
+def test_upload_pif_non_async():
+    """
+    Tests that a PIF can be created, serialized, uploaded in *non async* mode
+    """
+    pif = System()
+    pif.id = 0
+    uid = random_string()
+    pif.uid = uid
+
+    with open("tmp.json", "w") as fp:
+        dump(pif, fp)
+    assert client.upload(dataset_id, "tmp.json", is_async=False).successful()
+    tries = 0
+    while True:
+        try:
+            pif = client.get_pif(dataset_id, uid)
+            break
+        except ResourceNotFoundException:
+            if tries < 10:
+                tries += 1
+                time.sleep(1)
+            else:
+                raise
+
 def test_does_not_require_trailing_slash():
     src_path = "{}data_holder".format(test_file_data_root)
     result = client.upload(dataset_id, src_path)

--- a/citrination_client/models/client.py
+++ b/citrination_client/models/client.py
@@ -105,7 +105,7 @@ class ModelsClient(BaseClient):
         if not is_async:
             self._wait_for(
                 "Predict services ready",
-                lambda _: self.get_data_view_service_status(data_view_id).predict.ready,
+                lambda: self.get_data_view_service_status(data_view_id).predict.ready,
                 timeout)
 
         return True

--- a/citrination_client/models/tests/test_models_client.py
+++ b/citrination_client/models/tests/test_models_client.py
@@ -74,6 +74,16 @@ def test_retrain():
 
 
 @pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
+                    reason="Retrain tests only supported on open citrination")
+def test_retrain_non_async():
+    """
+    Test that we can trigger a retrain
+    """
+    resp = client.retrain("5909", is_async=False)
+    assert resp == True
+
+
+@pytest.mark.skipif(environ['CITRINATION_SITE'] != "https://citrination.com",
                     reason="Predict tests only supported on open citrination")
 def test_predict():
     """

--- a/citrination_client/views/client.py
+++ b/citrination_client/views/client.py
@@ -78,7 +78,7 @@ class DataViewsClient(BaseClient):
                 description
         }
 
-        failure_message = "Dataview creation failed"
+        failure_message = "Dataview update failed"
 
         self._patch_json(
             'v1/data_views/' + data_view_id, data, failure_message=failure_message)

--- a/citrination_client/views/client.py
+++ b/citrination_client/views/client.py
@@ -54,7 +54,7 @@ class DataViewsClient(BaseClient):
         if not is_async:
             self._wait_for(
                 "Predict services ready",
-                lambda _: self.get_data_view_service_status(data_view_id).predict.ready,
+                lambda: self.get_data_view_service_status(data_view_id).predict.ready,
                 timeout)
 
         return data_view_id
@@ -86,7 +86,7 @@ class DataViewsClient(BaseClient):
         if not is_async:
             self._wait_for(
                 "Predict services ready",
-                lambda _: self.get_data_view_service_status(data_view_id).predict.ready,
+                lambda: self.get_data_view_service_status(data_view_id).predict.ready,
                 timeout)
 
     def delete(self, data_view_id):

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -61,7 +61,7 @@ def test_workflow():
 
         m.patch(
             data_view_url.format(site, '555'),
-            json=dict())
+            json=dict()
         )
 
         m.post(
@@ -137,7 +137,7 @@ def test_workflow_non_async():
 
         m.patch(
             data_view_url.format(site, '555'),
-            json=dict())
+            json=dict()
         )
 
         m.post(

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -132,7 +132,7 @@ def test_workflow_non_async():
 
         m.get(
             site + '/api/data_views/555/status',
-            json=dict(data={"data":{"status":{"predict":{"ready":True}}}})
+            json={"data":{"status":{"predict":{"ready":True}}}}
         )
 
         m.patch(

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -131,7 +131,7 @@ def test_workflow_non_async():
         )
 
         m.get(
-            data_view_url.format(site, '/555/status'),
+            site + '/api/data_views/555/status',
             json=dict(data={"data":{"status":{"predict":{"ready":True}}}})
         )
 

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -59,10 +59,15 @@ def test_workflow():
             json=dict(data=load_file_as_json('./citrination_client/views/tests/column_descriptors.json'))
         )
 
+        m.patch(
+            data_view_url.format(site, '555'),
+            json=dict())
+        )
+
         m.post(
             data_view_url.format(site, ''),
             json=dict(data=dict(id=555))
-        )
+        )      
 
         # Get available columns
         available_columns = search_template_client.get_available_columns([1234])
@@ -85,7 +90,7 @@ def test_workflow():
         assert data_view_id == 555
 
         # Update an ML template
-        data_views_client.update(555, dv_config, "my view", "my description")
+        data_views_client.update("555", dv_config, "my view", "my description")
 
 
 def test_workflow_non_async():
@@ -126,9 +131,19 @@ def test_workflow_non_async():
         )
 
         m.post(
+            data_view_url.format(site, '555/status'),
+            json=dict(data={"data":{"status":{"predict":{"ready":True}}}})
+        )
+
+        m.patch(
+            data_view_url.format(site, '555'),
+            json=dict())
+        )
+
+        m.post(
             data_view_url.format(site, ''),
             json=dict(data=dict(id=555))
-        )
+        )       
 
         # Get available columns
         available_columns = search_template_client.get_available_columns([1234])
@@ -151,7 +166,7 @@ def test_workflow_non_async():
         assert data_view_id == 555
 
         # Update an ML template
-        data_views_client.update(555, dv_config, "my view", "my description", is_async=False)
+        data_views_client.update("555", dv_config, "my view", "my description", is_async=False)
 
 
 def test_descriptor():

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -60,7 +60,7 @@ def test_workflow():
         )
 
         m.patch(
-            data_view_url.format(site, '555'),
+            data_view_url.format(site, '/555'),
             json=dict()
         )
 
@@ -131,12 +131,12 @@ def test_workflow_non_async():
         )
 
         m.post(
-            data_view_url.format(site, '555/status'),
+            data_view_url.format(site, '/555/status'),
             json=dict(data={"data":{"status":{"predict":{"ready":True}}}})
         )
 
         m.patch(
-            data_view_url.format(site, '555'),
+            data_view_url.format(site, '/555'),
             json=dict()
         )
 

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -132,7 +132,17 @@ def test_workflow_non_async():
 
         m.get(
             site + '/api/data_views/555/status',
-            json={"data":{"status":{"predict":{"ready":True}}}}
+            json={
+                    "data":{
+                        "status":{
+                            "predict":{
+                                "ready":True,
+                                "reason": None,
+                                "context": None
+                            }
+                        }
+                    }
+                }
         )
 
         m.patch(

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -139,6 +139,21 @@ def test_workflow_non_async():
                                 "ready":True,
                                 "reason": None,
                                 "context": None
+                            },
+                            "experimental_design":{
+                                "ready":True,
+                                "reason": None,
+                                "context": None
+                            },
+                            "data_reports":{
+                                "ready":True,
+                                "reason": None,
+                                "context": None
+                            },
+                            "model_reports":{
+                                "ready":True,
+                                "reason": None,
+                                "context": None
                             }
                         }
                     }

--- a/citrination_client/views/tests/test_model_template_builder.py
+++ b/citrination_client/views/tests/test_model_template_builder.py
@@ -130,7 +130,7 @@ def test_workflow_non_async():
             json=dict(data=load_file_as_json('./citrination_client/views/tests/column_descriptors.json'))
         )
 
-        m.post(
+        m.get(
             data_view_url.format(site, '/555/status'),
             json=dict(data={"data":{"status":{"predict":{"ready":True}}}})
         )


### PR DESCRIPTION
@Imperssonator and I put together some additions that allow you to make some API calls and turn off async (e.g., you can create a data view and have the function wait to return until the initial models are trained and predict is ready).

tl;dr of changes, major to minor:
- Added a base waiting function
- data / models / views call this wait function in some API calls with an optional `is_async=False` arg
- added tests to ensure these non async routes work (involves some new mock routes)
- also added mock routes / tests for view updating (async and non async)
- minor documentation fixes