### PR TITLE
Add ModelReport class and ViewsClient#get_model_reports endpoint

### DIFF
--- a/citrination_client/views/client.py
+++ b/citrination_client/views/client.py
@@ -4,6 +4,7 @@ import time
 from citrination_client.models.client import ModelsClient
 
 from citrination_client.views.data_view_builder import DataViewBuilder
+from citrination_client.views.model_report import ModelReport
 from citrination_client.views.search_template.client import SearchTemplateClient
 
 from citrination_client import BaseClient, DataViewStatus, ServiceStatus
@@ -23,6 +24,7 @@ class DataViewsClient(BaseClient):
             "get_data_view_service_status",
             "create_ml_configuration_from_datasets",
             "create_ml_configuration",
+            "get_model_reports",
             "models",
             "search_template_client"
         ]
@@ -198,6 +200,10 @@ class DataViewsClient(BaseClient):
                 ml_config = self.__convert_response_to_configuration(config_status['result'], dataset_ids)
                 return ml_config
             time.sleep(5)
+
+    def get_model_reports(self, data_view_id):
+        response = self._get('v1/data_views/{}/model_reports'.format(data_view_id)).json()
+        return list(map(lambda report: ModelReport(report), response['data']))
 
     def __convert_response_to_configuration(self, result_blob, dataset_ids):
         """

--- a/citrination_client/views/client.py
+++ b/citrination_client/views/client.py
@@ -202,6 +202,14 @@ class DataViewsClient(BaseClient):
             time.sleep(5)
 
     def get_model_reports(self, data_view_id):
+        """
+        Retrieves the model reports of a data view
+
+        :param data_view_id: the id of the view to retrieve model reports from
+        :type data_view_id: str
+        :return: A list of model reports
+        :rtype: list of class:`ModelReport`
+        """
         response = self._get('v1/data_views/{}/model_reports'.format(data_view_id)).json()
         return list(map(lambda report: ModelReport(report), response['data']))
 

--- a/citrination_client/views/model_report.py
+++ b/citrination_client/views/model_report.py
@@ -15,18 +15,30 @@ class ModelReport(object):
 
     @property
     def model_name(self):
+        """
+        :rtype: str
+        """
         return self._raw_report['model_name']
 
     @property
     def performance(self):
+        """
+        :rtype: dict
+        """
         return self._raw_report['error_metrics']
 
     @property
     def feature_importances(self):
+        """
+        :rtype: list of dict
+        """
         return self._raw_report['feature_importances']
 
     @property
     def model_settings(self):
+        """
+        :rtype: dict
+        """
         return self._raw_report['model_settings']
 
     """

--- a/citrination_client/views/model_report.py
+++ b/citrination_client/views/model_report.py
@@ -1,0 +1,39 @@
+from copy import deepcopy
+
+class ModelReport(object):
+    """
+    An abstraction of a model report that wraps access to various sections
+    of the report.
+    """
+
+    """
+    :param raw_report: the dict representation of model report JSON
+    :type: dict
+    """
+    def __init__(self, raw_report):
+        self._raw_report = raw_report
+
+    @property
+    def model_name(self):
+        return self._raw_report['model_name']
+
+    @property
+    def performance(self):
+        return self._raw_report['error_metrics']
+
+    @property
+    def feature_importances(self):
+        return self._raw_report['feature_importances']
+
+    @property
+    def model_settings(self):
+        return self._raw_report['model_settings']
+
+    """
+    WARNING - the dict format returned is unstable and may change over time.
+
+    :return: a copy of the raw report that backs the instance.
+    :rtype: dict
+    """
+    def to_json(self):
+        return deepcopy(self._raw_report)


### PR DESCRIPTION
  The ViewsClient#get_model_reports endpoint returns a list of
  ModelReport instances.
  The ModelReport class serves as a wrapper around the model report
  JSON returned by Citrination, initially providing access to
  model performance, settings, and feature importances.