### PR TITLE
Custom ingester support

### DIFF
--- a/citrination_client/base/errors.py
+++ b/citrination_client/base/errors.py
@@ -44,3 +44,7 @@ class RequestPayloadTooLarge(CitrinationClientError):
 
     def __init__(self, message="Request payload too large", server_response=None):
         super(RequestPayloadTooLarge, self).__init__(message)
+
+class InvalidOptionError(CitrinationClientError):
+    def __init__(self, message):
+        super(InvalidOptionError, self).__init__(message)

--- a/citrination_client/data/client.py
+++ b/citrination_client/data/client.py
@@ -81,7 +81,10 @@ class DataClient(BaseClient):
                             dataset_id, current_source_path, current_dest_path
                         )
                         if file_upload_result.successful():
-                            upload_result.add_success(current_source_path)
+                            file_id = file_upload_result.successes[0]['id']
+                            upload_result.add_success(
+                                current_source_path, file_id, current_dest_path
+                            )
                         else:
                             upload_result.add_failure(
                                 current_source_path, "Upload failure"
@@ -126,7 +129,9 @@ class DataClient(BaseClient):
                     self._post_json(
                         routes.update_file(file_data['file_id']), data = data
                     )
-                    upload_result.add_success(source_path)
+                    upload_result.add_success(
+                        source_path, file_data['file_id'], path_data["dest_path"]
+                    )
                     return upload_result
                 else:
                     raise CitrinationClientError(

--- a/citrination_client/data/client.py
+++ b/citrination_client/data/client.py
@@ -2,6 +2,7 @@ from citrination_client.base.base_client import BaseClient
 from citrination_client.base.errors import *
 from citrination_client.data import *
 from citrination_client.data import routes as routes
+from citrination_client.data.ingest import IngestClient
 
 from pypif import pif
 
@@ -43,6 +44,9 @@ class DataClient(BaseClient):
         ]
         super(DataClient, self).__init__(
             api_key, host, members, suppress_warnings, proxies
+        )
+        self._ingest = IngestClient(
+            api_key, host, suppress_warnings, proxies
         )
 
     def upload(self, dataset_id, source_path, dest_path=None):
@@ -140,6 +144,45 @@ class DataClient(BaseClient):
 
         else:
             raise ValueError("No file at specified path {}".format(source_path))
+
+    def upload_with_ingester(self, dataset_id, source_path, ingester, ingester_arguments=[], dest_path=None):
+        """
+        Upload a file, specifying source and dest paths a file (acts as the scp command).asdfasdf
+
+        :param dataset_id: The ID of the dataset to search for files.
+        :type dataset_id: Union[int, str]
+        :param source_path: The path to the file on the source host asdf
+        :type source_path: str
+        :param ingester: The ingester being used
+        :type ingester: class:`citrination_client.data.ingest.Ingester`
+        :param ingester_arguments: ingester arguments (optional), arguments should
+                                   contain keys "name" and "value"
+        :type ingester_arguments: list of dict
+        :param dest_path: The path to the file where the contents of the upload will be written (on the dest host)
+        :type dest_path: str
+        :return: The result of the upload process
+        :rtype: :class:`UploadResult`
+        """
+        if not os.path.isfile(source_path):
+            raise ValueError("source_path parameter must point to a file".format(source_path))
+
+        self._ingest.validate_ingester(ingester, ingester_arguments)
+        file_upload_result = self.upload(dataset_id, source_path, dest_path)
+
+        if len(file_upload_result.successes) == 1:
+            file_path = file_upload_result.successes[0]["dest_path"]
+            self._ingest.submit(dataset_id, file_path, ingester, ingester_arguments)
+
+        return file_upload_result
+
+    def list_ingesters(self):
+        """
+        Retrieves the list of available ingesters
+
+        :return: The list of ingesters available for ingestion
+        :rtype: :class:`IngesterList`
+        """
+        return self._ingest.list_ingesters()
 
     def list_files(self, dataset_id, glob=".", is_dir=False):
         """

--- a/citrination_client/data/ingest/__init__.py
+++ b/citrination_client/data/ingest/__init__.py
@@ -1,0 +1,3 @@
+from citrination_client.data.ingest.ingester import Ingester
+from citrination_client.data.ingest.ingester_list import IngesterList
+from citrination_client.data.ingest.client import IngestClient

--- a/citrination_client/data/ingest/client.py
+++ b/citrination_client/data/ingest/client.py
@@ -1,0 +1,141 @@
+from citrination_client import BaseClient
+from citrination_client.data.ingest import IngesterList
+from citrination_client.data.ingest import Ingester
+
+class IngestClient(BaseClient):
+    """
+    Data Views client.
+    """
+
+    def __init__(self, api_key, site="https://citrination.com", suppress_warnings=False, proxies=None):
+        members = ["list_ingesters", "submit"]
+        super(IngestClient, self).__init__(
+            api_key, site, members, suppress_warnings, proxies
+        )
+
+    def list_ingesters(self):
+        """
+        Retrieves the list of available ingesters
+
+        :return: The list of ingesters available for ingestion
+        :rtype: :class:`IngesterList`
+        """
+        response = self._get_success_json(
+            self._get(
+                'v1/ingest/list_ingesters',
+                failure_message='Failed to retrieve available ingesters'
+            ),
+        )['ingesters']
+
+        return IngesterList(response)
+
+    def submit(self, dataset_id, file_path, ingester, arguments = []):
+        """
+        Submits an ingest request using a custom (non-default) ingester
+
+        :param dataset_id: The dataset being uploaded to
+        :type dataset_id: str
+        :param file_path: The destination path of the file
+        :type file_path: str
+        :param ingester: The ingester being used
+        :type ingester: class:`citrination_client.data.ingest.Ingester`
+        :param arguments: ingester arguments (optional), arguments should
+                          contain keys "name" and "value"
+        :type arguments: list of dict
+        """
+        ingester_with_values = self._apply_ingester_arguments(
+            ingester, arguments
+        )
+        data = {
+            "ingester": ingester_with_values.to_json(),
+            "dataset_id": dataset_id,
+            "target_path": file_path
+        }
+
+        self._get_success_json(
+            self._post_json(
+                'v1/ingest/submit',
+                data,
+                failure_message='Failed to submit ingestion request'
+            )
+        )
+
+    def validate_ingester(self, ingester, arguments = []):
+        """
+        Validates that the ingester and argument values are valid.
+
+        :param ingester: The ingester being used
+        :type ingester: class:`citrination_client.data.ingest.Ingester`
+        :param arguments: ingester arguments (optional), arguments should
+                          contain keys "name" and "value"
+        :type arguments: list of dict
+        """
+        ingester_with_values = self._apply_ingester_arguments(ingester, arguments)
+        self._get_success_json(
+            self._post_json(
+                'v1/ingest/validate_ingester',
+                { "ingester": ingester_with_values.to_json() },
+                failure_message='Failed to submit ingestion request'
+            )
+        )
+
+    def _apply_ingester_arguments(self, ingester, arguments = []):
+        """
+        Validates that the ingester and arguments passed to the #submit method
+        are valid, and applies those arguments to a copy of the ingester.
+
+        :param ingester: The ingester being used
+        :type ingester: class:`citrination_client.data.ingest.Ingester`
+        :param arguments: ingester arguments (optional), arguments should
+                          contain keys "name" and "value"
+        :type arguments: list of dict
+        :return: a copy of the ingester with the argument values applied
+        :rtype: citrination_client.data.ingest.Ingester
+        """
+        if not isinstance(ingester, Ingester):
+            raise TypeError(
+                "Expected ingester to be an instance of Ingester, received {}".format(
+                    ingester.__class__
+                )
+            )
+        else:
+            self._validate_arguments_shape(arguments)
+
+        ingester_copy = ingester.clone()
+
+        for argument in arguments:
+            ingester_copy.find_argument(argument['name'])['value'] = argument['value']
+
+        return ingester_copy
+
+    def _validate_arguments_shape(self, arguments):
+        """
+        Validates the shape of the arguments passed into _apply_ingester_arguments -
+        that they are an array of dicts containing 'name' and 'value' keys
+
+        :param arguments: ingester arguments (optional), arguments should
+                          contain keys "name" and "value"
+        :type arguments: list of dict
+        """
+        if not isinstance(arguments, list):
+            raise TypeError(
+                "Expected arguments to be an instance of list, received {}".format(
+                    arguments.__class__
+                )
+            )
+        else:
+            improper_arguments = list(
+                filter(
+                    lambda arg: (
+                        not isinstance(arg, dict) or
+                        not 'name' in arg or
+                        not 'value' in arg
+                    ),
+                    arguments
+                )
+            )
+            if len(improper_arguments) > 0:
+                raise TypeError(
+                    "Expected all arguments to be dictionaries containing " \
+                    "'name' and 'value' keys"
+                )

--- a/citrination_client/data/ingest/ingester.py
+++ b/citrination_client/data/ingest/ingester.py
@@ -1,0 +1,104 @@
+from citrination_client.base import InvalidOptionError, CitrinationClientError
+from copy import deepcopy
+
+class ArgumentNotFoundError(CitrinationClientError):
+    def __init__(self, message):
+        super(message)
+
+class Ingester:
+    """
+    Class representation of an ingester
+    """
+
+    SEARCH_FIELDS = set([
+        'description', 'display_name', 'name', 'namespace', 'version', 'id'
+    ])
+
+    def __init__(self, ingester):
+        """
+        Constructor.
+
+        :param ingester: An ingester
+        :type ingester: dict
+        """
+        self._ingester = ingester;
+        self.display_name = ingester['display_name']
+        self.description = ingester['description']
+        self.namespace = ingester['namespace']
+        self.name = ingester['name']
+        self.version = ingester['version']
+        self.id = ingester['id']
+        self.arguments = deepcopy(ingester['arguments']) or []
+
+    @classmethod
+    def validate_search_key(klass, key, suppress_error = True):
+        """
+        Returns whether or not a key correlates to a field that can be searched
+
+        :param key: The key to check
+        :type key: str
+        :param suppress_error: When false, will raise an error for invalid keys
+        :type key: bool
+        :return: True if the key is valid, otherwise false
+        :rtype: bool
+        """
+        key_present = key in klass.SEARCH_FIELDS
+
+        if key_present or suppress_error:
+            return key_present
+        elif not key_present:
+            raise InvalidOptionError(
+                'Invalid key {}, accepted keys are {}'.format(
+                    key, klass.SEARCH_FIELDS
+                )
+            )
+
+    def clone(self):
+        """
+        Returns a copy of the ingester. Used by the IngestClient to apply values
+        to a copy of the selected ingester before submission.
+
+        :return: Returns a copy of the ingester based on a deep clone of the
+                 _ingester dict that instantiated the instance.
+        :return: class:`Ingester`
+        """
+        return self.__class__(deepcopy(self._ingester))
+
+    def find_argument(self, name):
+        """
+        Finds an argument in self.arguments that matches the provided name.
+        If there are no matches, raises an ArgumentNotFoundError
+
+        :param name: The name of the argument
+        :type name: str
+        :return: The argument whose name matched
+        :rtype: dict
+        """
+        try:
+            # Find the first argument whose name matches
+            return next(
+                filter(lambda argument: argument['name'] == name, self.arguments)
+            )
+        except StopIteration:
+            raise ArgumentNotFoundError(
+                'Unable to find argument with name {}'.format(name)
+            )
+
+    def to_json(self):
+        """
+        Returns a dict that can used for ingest submission
+
+        :return: A dict representation of the ingester
+        :rtype: dict
+        """
+        return {
+            "id": self.id,
+            "name": self.name,
+            "namespace": self.namespace,
+            "version": self.version,
+            "display_name": self.display_name,
+            "description": self.description,
+            "arguments": self.arguments
+        }
+
+    # def validate_inputs(self, inputs):

--- a/citrination_client/data/ingest/ingester.py
+++ b/citrination_client/data/ingest/ingester.py
@@ -101,4 +101,3 @@ class Ingester:
             "arguments": self.arguments
         }
 
-    # def validate_inputs(self, inputs):

--- a/citrination_client/data/ingest/ingester_list.py
+++ b/citrination_client/data/ingest/ingester_list.py
@@ -1,6 +1,5 @@
 from citrination_client.data.ingest import Ingester
 from citrination_client.base import CitrinationClientError
-import pdb
 
 class IngesterNotFoundError(CitrinationClientError):
     def __init__(self, message):

--- a/citrination_client/data/ingest/ingester_list.py
+++ b/citrination_client/data/ingest/ingester_list.py
@@ -1,0 +1,117 @@
+from citrination_client.data.ingest import Ingester
+from citrination_client.base import CitrinationClientError
+import pdb
+
+class IngesterNotFoundError(CitrinationClientError):
+    def __init__(self, message):
+        super(message)
+
+class IngesterList:
+    """
+    Class representation of a list of ingesters available for data upload on
+    Citrination.
+    """
+
+    def __init__(self, ingesters):
+        """
+        Constructor.
+
+        :param ingesters: A list of ingesters
+        :type ingesters: Union[list, :class:`IngesterList`]
+        """
+        if not isinstance(ingesters, list):
+            raise TypeError('Expected ingesters to be of type list')
+        else:
+            self.ingesters = list(
+                map(
+                    lambda ingester: self._coerce_ingester(ingester), ingesters
+                )
+            )
+
+    @property
+    def ingester_count(self):
+        """
+        Returns the count of how many Ingesters are in the list
+
+        :return: number of Ingesters in self.ingesters
+        :rtype: int
+        """
+        return len(self.ingesters)
+
+    def find_by_id(self, id):
+        """
+        Finds the ingester whose id matches the provided id
+
+        :param id: The id of the desired ingester
+        :type id: str
+
+        :return: An ingester
+        :rtype: :class:`Ingester`
+        """
+        try:
+            # Find the first ingester whose id matches
+            return next(
+                filter(lambda ingester: ingester.id == id, self.ingesters)
+            )
+        except StopIteration:
+            raise IngesterNotFoundError(
+                'Unable to find ingester with id {}'.format(id)
+            )
+
+    def where(self, options):
+        """
+        Finds ingesters that match the search criteria
+
+        :param options: contains string:string key value pairs, allowed keys
+                        are those found in the Ingester.SEARCH_FIELDS constant
+        :type dict
+
+        :return: A list of matching ingesters
+        :rtype: :class:`IngesterList`
+        """
+        self._validate_search_options(options)
+
+        # If options is empty, just return a new copy of the IngesterList
+        if not options:
+            return IngesterList(self.ingesters)
+
+        # Create a lambda that will check to see if all the values in the
+        # dictionary are found in the corresponding attributes of the ingester
+        #
+        # i.e. If options = { "name": "apple", "description": "banana" }, the
+        #      lambda will check that "apple" is in ingester.name and "banana"
+        #      is in ingester.description - both conditions would need to be met
+        #      in order for the lambda to return True
+        match_lambda = lambda ingester: all(
+            [value in getattr(ingester, key) for key, value in options.items()]
+        )
+
+        # Get a list of ingesters that match the search options
+        ingester_matches = list(filter(match_lambda, self.ingesters))
+
+        return IngesterList(ingester_matches)
+
+    def _coerce_ingester(self, ingester):
+        """
+        Helper method to ensure all members of the ingesters list are instances
+        of Ingester
+
+        :param ingester: either the dict or Ingester form of the ingester
+        :type ingester: Union[dict, :class:`Ingester`]
+
+        :return: an instance of Ingester
+        :rtype :class:`Ingester`
+        """
+        # Return the original ingester if it is already an instance of Ingester
+        return ingester if isinstance(ingester, Ingester) else Ingester(ingester)
+
+    def _validate_search_options(self, options):
+        if not isinstance(options, dict):
+            raise TypeError(
+                'Expected options to be of type dict, got {}'.format(
+                    options.__class__
+                )
+            )
+
+        # Check that the search keys are all valid
+        [Ingester.validate_search_key(key, False) for key in options]

--- a/citrination_client/data/tests/test_upload_result.py
+++ b/citrination_client/data/tests/test_upload_result.py
@@ -22,7 +22,7 @@ def test_add_success():
     result
     """
     ur = UploadResult()
-    ur.add_success("my/path.jpg")
+    ur.add_success("my/path.jpg", 2, "path.jpg")
     assert len(ur.successes) == 1
 
 def test_cant_write_lists():

--- a/citrination_client/data/upload_result.py
+++ b/citrination_client/data/upload_result.py
@@ -43,13 +43,17 @@ class UploadResult(object):
                 "reason": reason
             })
 
-    def add_success(self, filepath):
+    def add_success(self, filepath, id, dest_path):
         """
         Registers a file as successfully uploaded.
 
         :param filepath: The path to the successfully uploaded file.
         :type filepath: str
+        :param id: The id of the successfully uploaded file.
+        :type id: Union[str, int]
+        :param dest_path: The destination path to the successfully uploaded file.
+        :type dest_path: str
         """
         self._successes.append({
-                "path": filepath
+                "path": filepath, "id": str(id), "dest_path": dest_path
             })


### PR DESCRIPTION
Create IngesterList and Ingester classes

      These IngesterList class will serve to abstract away the list of
      ingester dicts that are available on a Citrination deployment, allowing
      consumers to find the ingester they want to use either via #find_by_id or
      one or more #where calls.

      The Ingester class serves as an abstraction of an ingester dict. It provides
      methods for returning a copy of itself, finding an argument by name, and
      serialization for submission to Citrination.

Create IngestClient

      This client will be leveraged by the DataClient in order to retrieve
      available ingesters, validate ingesters before submission, and to
      handle ingest submissions.

Add custom ingestion endpoints to the DataClient

      Add instantiation of the IngestClient to the DataClient's
      initialization method.

      Add #list_ingesters method, which just invokes IngestClient#list_ingesters

      Add #upload_with_ingester method, which calls IngestClient#validate_ingester
      before making an ordinary file upload request via DataClient#upload, followed
      up by a call to IngestClient#submit to tell Citrination to use a particular
      ingester on the uploaded file.

