### PR TITLE
Feature/api documentation

### DIFF
--- a/citrination_client/data/ingest/client.py
+++ b/citrination_client/data/ingest/client.py
@@ -47,7 +47,7 @@ class IngestClient(BaseClient):
             ingester, arguments
         )
         data = {
-            "ingester": ingester_with_values.to_json(),
+            "ingester": ingester_with_values.as_json(),
             "dataset_id": dataset_id,
             "target_path": file_path
         }
@@ -74,7 +74,7 @@ class IngestClient(BaseClient):
         self._get_success_json(
             self._post_json(
                 'v1/ingest/validate_ingester',
-                { "ingester": ingester_with_values.to_json() },
+                { "ingester": ingester_with_values.as_json() },
                 failure_message='Failed to submit ingestion request'
             )
         )

--- a/citrination_client/data/ingest/ingester.py
+++ b/citrination_client/data/ingest/ingester.py
@@ -97,7 +97,7 @@ class Ingester:
                 'Unable to find argument with name {}'.format(name)
             )
 
-    def to_json(self):
+    def as_json(self):
         """
         Returns a dict that can used for ingest submission
 

--- a/citrination_client/data/ingest/ingester.py
+++ b/citrination_client/data/ingest/ingester.py
@@ -113,3 +113,8 @@ class Ingester:
             "description": self.description,
             "arguments": self.arguments
         }
+
+    def __str__(self):
+        return "<Ingester id='{}' display_name='{}' description='{}' num_arguments={}>".format(
+            self.id, self.display_name, self.description, len(self.arguments)
+        )

--- a/citrination_client/data/ingest/ingester.py
+++ b/citrination_client/data/ingest/ingester.py
@@ -8,6 +8,15 @@ class ArgumentNotFoundError(CitrinationClientError):
 class Ingester:
     """
     Class representation of an ingester
+
+    :ivar str ~.display_name:
+    :ivar str ~.description:
+    :ivar str ~.namespace:
+    :ivar str ~.name:
+    :ivar str ~.version:
+    :ivar str ~.id:
+    :ivar ~.arguments: any optional and/or required arguments for the ingester
+    :vartype ~.arguments: list of dict
     """
 
     SEARCH_FIELDS = set([

--- a/citrination_client/data/ingest/ingester_list.py
+++ b/citrination_client/data/ingest/ingester_list.py
@@ -124,3 +124,9 @@ class IngesterList:
 
         # Check that the search keys are all valid
         [Ingester.validate_search_key(key, False) for key in options]
+
+    def __str__(self):
+        return "<IngesterList ingester_count={} ingesters={}>".format(
+            self.ingester_count,
+            list(map(lambda ingester: str(ingester), self.ingesters))
+        )

--- a/citrination_client/data/ingest/ingester_list.py
+++ b/citrination_client/data/ingest/ingester_list.py
@@ -9,6 +9,9 @@ class IngesterList:
     """
     Class representation of a list of ingesters available for data upload on
     Citrination.
+
+    :ivar ~.ingesters:
+    :vartype ~.ingesters: list of :class:`Ingester`
     """
 
     def __init__(self, ingesters):
@@ -32,7 +35,7 @@ class IngesterList:
         """
         Returns the count of how many Ingesters are in the list
 
-        :return: number of Ingesters in self.ingesters
+        :return: number of Ingesters in the list
         :rtype: int
         """
         return len(self.ingesters)

--- a/citrination_client/views/model_report.py
+++ b/citrination_client/views/model_report.py
@@ -49,3 +49,8 @@ class ModelReport(object):
     """
     def as_json(self):
         return deepcopy(self._raw_report)
+
+    def __str__(self):
+        return "<ModelReport model_name='{}'>".format(
+            self.model_name
+        )

--- a/citrination_client/views/model_report.py
+++ b/citrination_client/views/model_report.py
@@ -47,5 +47,5 @@ class ModelReport(object):
     :return: a copy of the raw report that backs the instance.
     :rtype: dict
     """
-    def to_json(self):
+    def as_json(self):
         return deepcopy(self._raw_report)

--- a/docs/source/modules/views/model_report.rst
+++ b/docs/source/modules/views/model_report.rst
@@ -1,0 +1,5 @@
+Model Report
+=================
+
+.. automodule:: citrination_client.views.model_report
+    :members:


### PR DESCRIPTION
Add module documentation for ModelReport class

Add instance variable documentation for Ingester and IngesterList

Rename newly created #to_json methods to #as_json

      These methods actually return structures that would be suitable
      for converting to JSON; they do not return valid JSON.

Implement #__str__ on Ingester, IngesterList, and ModelReport classes

      These provide a little better overview of the instances when printing
      them to logs or in interactive environments.