### PR TITLE
Release 6.0.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ author = u'Citrine Informatics'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'6.0.0'
+release = u'6.0.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ author = u'Citrine Informatics'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'5.4.0'
+release = u'6.0.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ author = u'Citrine Informatics'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'5.3.0'
+release = u'5.4.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,21 +20,47 @@ Use the articles in this section to familiarize yourself with the basic usage of
 Upgrading
 ---------
 
-If you are using a version of PyCC older than 5.0.0 and would like to upgrade your scripts to the latest versions, please
+If you are using a version of PyCC older than 6.0.0 and would like to upgrade your scripts to the latest versions, please
 note the following:
 
+Changes from 4.x to 5.x
+^^^^^^^^^^^^^^^^^^^^^^^
 1. When building data views, you now have to specify upper and lower bounds.
-2. When making certain prediction/design calls, things previously under `client.data_views` are now under `client.models`
-3. You have to specify the subclient, e.g. `client.data.upload()` not just `client.upload()`
+2. When making certain prediction/design calls, things previously under
+   ``client.data_views`` are now under ``client.models``
+3. You have to specify the subclient, e.g. ``client.data.upload()`` not just ``client.upload()``
 
+Changes from 5.x to 6.x
+^^^^^^^^^^^^^^^^^^^^^^^
+1. New Features
 
-If you already have ``citrination-client`` installed (either in your virtual environment or your global set of ``pip`` packages), you can upgrade to v5.x like this:
+  * **Custom Ingester Support** - allows for the usage of custom ingesters when
+    uploading files. See ``DataClient.list_ingesters``, ``DataClient.upload_with_ingester``,
+    and ``DataClient.upload_with_template_csv_ingester``, ``Ingester``, and ``IngesterList``
+    classes.
+  * **Model Reports** - first pass access to ``model settings``, ``feature importances``,
+    and ``model performance metrics`` for data views with ML configured. See
+    ``ViewsClient.get_model_reports`` and ``ModelReport`` class.
+
+2. Deprecations
+
+  * The **ModelsClient.get_data_view** method has been deprecated in favor of **ViewsClient.get**.
+  * The **DataView** class has been removed - it was previously only used by ``ModelsClient.get_data_view``.
+
+3. Minor Changes
+
+  * Error message propagation for **404** errors - this should give more friendly error
+    messages when resources being acted upon are not found. For example instead of
+    the generic ``Resource Not Found`` message, one might get a ``Dataset 1234 was not found``
+    message.
+
+If you already have ``citrination-client`` installed (either in your virtual environment or your global set of ``pip`` packages), you can upgrade to v6.x like this:
 
 .. code-block:: python
 
     pip install --upgrade citrination-client
 
-If you do this in an existing project, be sure to update your ``requirements.txt`` file to point to version 5.1.1 or newer.
+If you do this in an existing project, be sure to update your ``requirements.txt`` file to point to version 6.0.0 or newer.
 
 
 Module Documentation

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='5.4.0',
+      version='6.0.0',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(exclude=('docs')),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='5.3.0',
+      version='5.4.0',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(exclude=('docs')),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='citrination-client',
-      version='6.0.0',
+      version='6.0.1',
       url='http://github.com/CitrineInformatics/python-citrination-client',
       description='Python client for accessing the Citrination api',
       packages=find_packages(exclude=('docs')),


### PR DESCRIPTION
Add documentation notes regarding upgrading pycc from v4 to v6

      Add notes to introduction regarding changes from pycc 4.x to 5.x,
      and from 5.x to 6.x.