### PR TITLE
Feature/get pif with metadata

### DIFF
--- a/citrination_client/data/client.py
+++ b/citrination_client/data/client.py
@@ -41,6 +41,7 @@ class DataClient(BaseClient):
             "create_dataset_version",
             "get_ingest_status",
             "get_pif",
+            "get_pif_with_metadata",
             "update_dataset",
             "delete_dataset",
             "get_data_view_ids"
@@ -382,6 +383,42 @@ class DataClient(BaseClient):
         response = self._get(path, failure_message=failure_message)
 
         return pif.loads(response.content.decode("utf-8"))
+
+    def get_pif_with_metadata(self, dataset_id, uid, dataset_version = None, pif_version = None):
+        """
+        Retrieves a PIF from a given dataset, along with information regarding
+        the dataset it belongs to, its version number, and when it was last
+        updated.
+
+        :param dataset_id: The id of the dataset to retrieve PIF from
+        :type dataset_id: int
+        :param uid: The uid of the PIF to retrieve
+        :type uid: str
+        :param dataset_version: The dataset version to look for the PIF in.
+            If nothing is supplied, the latest dataset version will be searched.
+        :type dataset_version: int
+        :param pif_version: The version of the PIF to look for. If nothing is
+            supplied, the current PIF version will be returned.
+        :type pif_version: int
+        :return: A dict with two keys - ``pif`` (:class:`Pif`) and ``metadata`` (dict)
+        :rtype: dict
+        """
+        failure_message = "An error occurred retrieving PIF {}".format(uid)
+        path = _get_pif_path(
+            dataset_id,
+            uid,
+            dataset_version = dataset_version,
+            pif_version = pif_version,
+            with_metadata = True
+        )
+        response = self._get_success_json(
+            self._get(path, failure_message=failure_message)
+        )['data']
+
+        return {
+            'metadata': response['metadata'],
+            'pif': pif.loads(json.dumps(response['pif']))
+        }
 
     def create_dataset(self, name=None, description=None, public=False):
         """

--- a/citrination_client/data/routes.py
+++ b/citrination_client/data/routes.py
@@ -9,11 +9,20 @@ def list_files(dataset_id):
 def matched_files(dataset_id):
     return 'datasets/{}/download_files'.format(dataset_id)
 
-def pif_dataset_uid(dataset_id, pif_uid):
-    return 'datasets/{}/pif/{}'.format(dataset_id, pif_uid)
+def pif_dataset_uid(dataset_id, pif_uid, pif_version = None, with_metadata = False):
+    url = 'datasets/{}/pif/{}'.format(dataset_id, pif_uid)
+    return _get_pif_url_helper(url, pif_version, with_metadata)
 
-def pif_dataset_version_uid(dataset_id, version, pif_uid):
-    return 'datasets/{}/version/{}/pif/{}'.format(dataset_id, version, pif_uid)
+def pif_dataset_version_uid(dataset_id, version, pif_uid, pif_version = None, with_metadata = False):
+    url = 'datasets/{}/version/{}/pif/{}'.format(dataset_id, version, pif_uid)
+    return _get_pif_url_helper(url, pif_version, with_metadata)
+
+def _get_pif_url_helper(url, pif_version, with_metadata):
+    if pif_version:
+        url += '/pif-version/{}'.format(pif_version)
+    if with_metadata:
+        url += '?with-metadata=true'
+    return url
 
 def create_dataset():
     return 'data_sets/create_dataset'


### PR DESCRIPTION
Add pif_version argument support to DataClient#get_pif

      The Citrination UI supports PIF versioning on the current dataset version,
      adding this to the API for all dataset versions since it's fairly light
      lift.
      Also refactor path generation in preparation for DataClient#get_pif_with_metadata
      method, to support with-metadata query string parameter.

Add DataClient#get_pif_with_metadata method

      This method is similar to #get_pif, but in addition to retrieving the
      PIF, retrieves the dataset id and version, pif uid and version, and
      pif `updated at` attribute, wrapped up in a `metadata` dictionary.

Add basic test coverage for DataClient#get_pif_with_metadata

      Also bumped sleep time for the dataset update test, that frequently
      fails due to a race condition bug in Citrination.