### PR TITLE
Feature/get pif with metadata

### DIFF
--- a/citrination_client/data/tests/test_data_client.py
+++ b/citrination_client/data/tests/test_data_client.py
@@ -127,7 +127,7 @@ def test_dataset_update():
     dataset_name = random_dataset_name()
     dataset_id = client.create_dataset(name=dataset_name).id
     # Sleep added to accommodate race condition bug
-    time.sleep(20)
+    time.sleep(30)
     new_name = random_dataset_name()
     new_description = random_string()
     dataset = client.update_dataset(dataset_id, name=new_name, description=new_description)

--- a/docs/source/code_samples/data/get_pif.py
+++ b/docs/source/code_samples/data/get_pif.py
@@ -1,9 +1,20 @@
 # ... client initialization left out
 data_client = client.data
 dataset_id = 1
+pif_uid = "abc123"
 
-# Gets a single file named exactly my_file.json
+# Retrieves the latest version of the PIF with uid is "abc123" from the latest
+# version of dataset 1
+data_client.get_pif(dataset_id, pif_uid)
 
-data_client.get_pif(dataset_id, "1DF1C8EB706363DS2G3")
+# Retrieves the latest version of the PIF with uid is "abc123" from version 3
+# of dataset 1
+data_client.get_pif(dataset_id, pif_uid, dataset_version = 3)
 
-# Returns a Pif object from the PyPif library
+# Retrieves the version 2 of the PIF with uid is "abc123" from the latest version
+# of dataset 1
+data_client.get_pif(dataset_id, pif_uid, pif_version = 2)
+
+# Retrieves the version 2 of the PIF with uid is "abc123" from version 3 of
+# dataset 1
+data_client.get_pif(dataset_id, pif_uid, dataset_version = 3, pif_version = 2)

--- a/docs/source/code_samples/data/get_pif_with_metadata.py
+++ b/docs/source/code_samples/data/get_pif_with_metadata.py
@@ -1,0 +1,15 @@
+# ... client initialization left out
+data_client = client.data
+dataset_id = 105924
+pif_uid = "1DF1C8EB706363E40546253D5D025D90"
+
+get_pif_with_metadata = data_client.get_pif_with_metadata(dataset_id, pif_uid)
+
+print(get_pif_with_metadata)
+# {'metadata': {
+#     'uid': '1DF1C8EB706363E40546253D5D025D90',
+#     'version': 1,
+#     'dataset_id': '105924',
+#     'dataset_version': 1,
+#     'updated_at': '2017-07-04T19:41:40.139Z'},
+#  'pif': <pypif.obj.system.chemical.chemical_system.ChemicalSystem at 0x1131b8a50>}

--- a/docs/source/tutorial/data_examples.rst
+++ b/docs/source/tutorial/data_examples.rst
@@ -227,10 +227,24 @@ one or more files in a dataset.
 PIF Retrieval
 ^^^^^^^^^^^^^
 
-A PIF record on Citrination can be retrieved using the `get_pif()` method.
-The record will be returned as a PyPif Pif object.
+A PIF record on Citrination can be retrieved using the ``DataClient#get_pif`` method.
+The record will be returned as a PyPif Pif object. The ``dataset_version`` and
+``pif_version`` arguments are optional - by default the PIF returned will be
+the current version of the PIF from the current version of the dataset.
 
 .. literalinclude:: /code_samples/data/get_pif.py
+
+To get the metadata of a PIF, use the ``DataClient#get_pif_with_metadata`` method.
+This method acts similar to ``DataClient#get_pif``, but returns a dictionary
+instead of a PyPif Pif object. The resulting dictionary will have two keys:
+`"pif"`, which will point to a PyPif Pif object, and `"metadata"`, which will be
+a dictionary with `"dataset_id"`, `"dataset_version"`, `"uid"`, `"version"`, and
+`"updated_at"` keys.
+
+``DataClient#get_pif_with_metadata`` has the same method signature as ``DataClient#get_pif``,
+with optional ``dataset_version`` and ``pif_version`` arguments.
+
+.. literalinclude:: /code_samples/data/get_pif_with_metadata.py
 
 Dataset Manipulation
 --------------------


### PR DESCRIPTION
Bump sleep amount from 20 to 30s in test

      Bumping from 10 to 20 looks to have improved things slightly, bumping
      to 30s to see if this improves it further.

Update DataClient tutorial regarding Pif Retrieval

      Add example of using optional `dataset_version` and `pif_version`
      arguments in `DataClient#get_pif`.
      Add section on usage of `DataClient#get_pif_with_metadata`.