### PR TITLE
using os.path.realpath for symbolic link case

### DIFF
--- a/citrination_client/__init__.py
+++ b/citrination_client/__init__.py
@@ -30,8 +30,9 @@ def __get_version():
     try:
         _dist = get_distribution('citrination_client')
         # Normalize case for Windows systems
-        dist_loc = os.path.normcase(_dist.location)
-        here = os.path.normcase(__file__)
+        # Using realpath in case directories are symbolic links
+        dist_loc = os.path.realpath(os.path.normcase(_dist.location))
+        here = os.path.realpath(os.path.normcase(__file__))
         if not here.startswith(os.path.join(dist_loc, 'citrination_client')):
             # not installed, but there is another version that *is*
             raise DistributionNotFound


### PR DESCRIPTION
I have this failure on Jenkins:
https://jenkins.corp.citrine.io/job/citrine-e2e-examples.pr/181/console

`dist_loc` is different than `here` because one uses a symbolic link:
```
here: /tmp/jenkins-40941e33/workspace/citrine-e2e-examples.pr/venv/lib64/python3.6/site-packages/citrination_client/_init_.py
dist_loc: /tmp/jenkins-40941e33/workspace/citrine-e2e-examples.pr/venv/lib/python3.6/site-packages
```

This fix uses `os.path.realpath` which should eliminate symbolic links that are in the path.